### PR TITLE
upgrade lib.deno.d.ts to 1.0.0-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,6 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
-    "typescript-deno-plugin": "^1.14.0"
+    "typescript-deno-plugin": "^1.15.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,10 +1402,10 @@ typed-rest-client@1.2.0:
     tunnel "0.0.4"
     underscore "1.8.3"
 
-typescript-deno-plugin@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/typescript-deno-plugin/-/typescript-deno-plugin-1.14.0.tgz#3a439c645d3a0bacf946eb7556226fcdf45884e0"
-  integrity sha512-r5sR3iL6QN7Qyj/fI1V86HUkPPGlPSB8W6NM6J8Ka51yhgtDDNnbMFGckwXlNzJDqgecRHpW4JvgR3ibGMID6w==
+typescript-deno-plugin@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/typescript-deno-plugin/-/typescript-deno-plugin-1.15.0.tgz#5e0ebe28be6c996241775289586ad3ddcff52d4e"
+  integrity sha512-/u0ngHsd+wduuMZN4yCoPI34I9d5O4byi8bTliY44Yqb0WcU/AXuYAdnmXl2ibFnvvrYoZ+8hj8yfvsGxExzzw==
   dependencies:
     crypto "^1.0.1"
     import-maps "^0.2.1"


### PR DESCRIPTION
via https://github.com/justjavac/typescript-deno-plugin/commit/41b28727c5f0e2b6fc917315d0b7ce16d0482b5a

--------

How the extension works: If user installs Deno, the lib.deno.d.ts file will be created by `deno types`  when the extension is initialized. If user has not installed Deno, will use the extension bundled lib.deno.d.ts file, which is the latest version.

Another implementation is to download the lib.deno.d.ts file from github. Fortunately, starting from version 0.39.0, Deno's releases assets include the lib.deno.d.ts file.

https://github.com/denoland/vscode_deno/blob/f5d6c124d4dc6e0a0a63eaf918327f78b01063a2/client/src/utils.ts#L238-L239