### PR TITLE
show changelog on vscode marketplace

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,8 @@ rm -rf **/*.tsbuildinfo
 yarn compile
 
 # Copy files to package root
-cp package.* yarn.lock deno.png Releases.md README.md dist
+cp package.* yarn.lock deno.png README.md dist
+cp Releases.md dist/Changelog.md
 cp -r schemas dist
 # Copy files to client directory
 cp client/package.json client/yarn.lock dist/client


### PR DESCRIPTION
vscode marketplace do not display `Release.md` on the right aside, just only `changelog.*`.

![](https://user-images.githubusercontent.com/359395/81627985-fd2b4080-9431-11ea-8797-430ff06972f2.png)

