### PR TITLE
Add deno.unstable configuration

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -157,6 +157,7 @@ interface SynchronizedConfiguration {
   enable?: boolean;
   importmap?: string;
   tsconfig?: string;
+  unstable?: boolean;
 }
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -448,6 +449,7 @@ function getConfiguration(): SynchronizedConfiguration {
   withConfigValue(config, outConfig, "autoFmtOnSave");
   withConfigValue(config, outConfig, "tsconfig");
   withConfigValue(config, outConfig, "importmap");
+  withConfigValue(config, outConfig, "unstable");
 
   return outConfig;
 }

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -140,6 +140,7 @@ export function getExtensionPath(extensionId: string): string | undefined {
 export async function generateDtsForDeno(extensionId: string): Promise<void> {
   const denoDir: string = getDenoDir();
   const extensionPath = getExtensionPath(extensionId)!;
+
   const bundledPath = bundledDtsPath(extensionPath);
 
   if (!fs.existsSync(denoDir)) {
@@ -154,7 +155,13 @@ export async function generateDtsForDeno(extensionId: string): Promise<void> {
   );
 
   try {
-    const { stdout, stderr } = await execa("deno", ["types", "--unstable"]);
+    const args = ["types"];
+    const config = vscode.workspace.getConfiguration();
+
+    console.log("reloading...");
+    if (config.get("deno.unstable")) args.push("--unstable");
+
+    const { stdout, stderr } = await execa("deno", args);
 
     if (stderr) {
       throw stderr;

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -158,7 +158,6 @@ export async function generateDtsForDeno(extensionId: string): Promise<void> {
     const args = ["types"];
     const config = vscode.workspace.getConfiguration();
 
-    console.log("reloading...");
     if (config.get("deno.unstable")) args.push("--unstable");
 
     const { stdout, stderr } = await execa("deno", args);

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "vscode_deno",
+  "name": "deno",
   "displayName": "%deno.displayName%",
   "description": "%deno.description%",
   "version": "1.24.0",
-  "publisher": "the deno authors",
+  "publisher": "denoland",
   "icon": "deno.png",
   "galleryBanner": {
     "color": "#3B3738",
@@ -106,6 +106,11 @@
           ],
           "default": "terse",
           "description": "Enables logging of the Deno server to a file. This log can be used to diagnose Deno Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
+        },
+        "deno.unstable": {
+          "type": "boolean",
+          "default": true,
+          "description": "%deno.config.unstable%"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "deno",
+  "name": "vscode_deno",
   "displayName": "%deno.displayName%",
   "description": "%deno.description%",
   "version": "1.24.0",
-  "publisher": "denoland",
+  "publisher": "the deno authors",
   "icon": "deno.png",
   "galleryBanner": {
     "color": "#3B3738",

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,5 +8,6 @@
   "deno.config.alwaysShowStatus": "Always show the Deno status bar item.",
   "deno.config.autoFmtOnSave": "Turns auto format on save on or off.",
   "deno.config.dtsPath": "The Path of TypeScript declaration file(.d.ts).",
-  "deno.config.importmap": "The Path of import maps."
+  "deno.config.importmap": "The Path of import maps.",
+  "deno.config.unstable": "Enable Deno unstable features."
 }


### PR DESCRIPTION
* Added `deno.unstable` as configuration option
* Changed extension name to `deno` and publisher to `denoland`

## Motivation
A user might not want to support unstable Deno features and should have the option to choose if enable unstable type definition