### PR TITLE
Fix incorrect configuration string in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can configure the Deno extension using a `tsconfig` as described
 configure it with VS Code settings. This requires VS Code 1.40+ and TS 3.8+.
 Note the VS Code based configuration overrides the `tsconfig` configuration.
 
-- `deno.enabled` - Enable/disable this extension. Default is `true`.
+- `deno.enable` - Enable/disable this extension. Default is `true`.
 
 - `deno.alwaysShowStatus` - Always show the Deno status bar item. Default is `true`.
 


### PR DESCRIPTION
This pull request changes the incorrect configuration string `deno.enabled` to `deno.enable` in the README.