### PR TITLE
Add "enablePatterns" config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Note the VS Code based configuration overrides the `tsconfig` configuration.
 
 - `deno.enable` - Enable/disable this extension. Default is `true`.
 
+- `deno.enablePatterns` - An array of regexes that matches files Deno should be enabled on. Default is `["*"]` (matches all files). Paths are relative to the workspaces directory, so for example `["packages/"']` will look for the `packages` folder in your project.
+
 - `deno.alwaysShowStatus` - Always show the Deno status bar item. Default is `true`.
 
 - `deno.importmap` - The Path of import maps. Default is `null`.

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -158,6 +158,7 @@ interface SynchronizedConfiguration {
   importmap?: string;
   tsconfig?: string;
   unstable?: boolean;
+  enablePatterns?: string[];
 }
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -374,8 +375,20 @@ export async function activate(context: vscode.ExtensionContext) {
         token: vscode.CancellationToken,
         next: lsp.ProvideCodeActionsSignature,
       ) {
-        if (!config.get("deno.enable") || !context.diagnostics) {
-          return [];
+        if (!context.diagnostics) return [];
+        if (!config.get("deno.enable")) return [];
+
+        // If deno.enablePatterns is specified and this file doesn't
+        // match a path, then disable Deno.
+        const paths = (config.get("deno.enablePatterns") || ["*"]) as string[];
+        if (paths && paths.length) {
+          const localFileName = document.fileName
+            .replace(vscode.workspace.rootPath, "");
+          const matchesPath = paths
+            .findIndex((p) => RegExp(p).test(localFileName));
+          if (!matchesPath) {
+            return [];
+          }
         }
 
         // diagnostics from Deno Language Server
@@ -460,6 +473,7 @@ function getConfiguration(): SynchronizedConfiguration {
   withConfigValue(config, outConfig, "tsconfig");
   withConfigValue(config, outConfig, "importmap");
   withConfigValue(config, outConfig, "unstable");
+  withConfigValue(config, outConfig, "enablePatterns");
 
   return outConfig;
 }
@@ -494,8 +508,11 @@ function withConfigValue<C, K extends Extract<keyof C, string>>(
 /** when package.json is detected in the root directory, display a prompt */
 async function promptForNodeJsProject(): Promise<void> {
   let enabled = vscode.workspace.getConfiguration("deno").get("enable", true);
+  let filtered = vscode.workspace.getConfiguration("deno").get(
+    "enablePatterns",
+  );
 
-  if (enabled && packageJsonExists()) {
+  if (enabled && !filtered && packageJsonExists()) {
     const disable = localize("button.disable", "Disable");
     const cancel = localize("button.cancel", "Cancel");
     const choice = await vscode.window.showInformationMessage(

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -7,6 +7,7 @@
   "deno.config.enabled": "Détermine si Deno doit être activé ou non.",
   "deno.config.packageManager": "Le gestionnaire de paquets utilisé pour les modules node.",
   "deno.config.alwaysShowStatus": "Toujours afficher Deno dans la barre de status.",
+  "deno.config.enablePatterns": "Les dossiers ou fichiers dans lesquels Deno doit être activé",
   "deno.config.autoFmtOnSave": "Active ou désactive le formatage automatique à la sauvegarde.",
   "deno.config.dtsPath": "Le chemin du fichier de déclarations de types TypeScript (.d.ts).",
   "deno.config.importmap": "Le chemin de votre fichier import map."

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -8,6 +8,7 @@
   "deno.config.packageManager": "Il gestore di pacchetti con cui installi i moduli node.",
   "deno.config.alwaysShowStatus": "Mostra sempre Deno sulla barra di stato.",
   "deno.config.autoFmtOnSave": "Attiva o disattiva la formattazione automatica dopo il salvataggio.",
+  "deno.config.enablePatterns": "Le cartelle o i file in cui Deno dovrebbe essere abilitato",
   "deno.config.dtsPath": "Il percorso per il file TypeScript declaration (.d.ts).",
   "deno.config.importmap": "Il percorso delle import map."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,6 +6,7 @@
   "deno.command.disable": "Disable Deno",
   "deno.config.enabled": "Controls whether deno is enabled or not.",
   "deno.config.packageManager": "The package manager you use to install node modules.",
+  "deno.config.enablePatterns": "The folders or files that deno should be enabled in",
   "deno.config.alwaysShowStatus": "Always show the Deno status bar item.",
   "deno.config.autoFmtOnSave": "Turns auto format on save on or off.",
   "deno.config.dtsPath": "The Path of TypeScript declaration file(.d.ts).",

--- a/package.nls.pt-pt.json
+++ b/package.nls.pt-pt.json
@@ -8,6 +8,7 @@
   "deno.config.packageManager": "O gestor de pacotes que você utiliza para instalar node modules.",
   "deno.config.alwaysShowStatus": "Mostrar sempre o Deno na barra de estados.",
   "deno.config.autoFmtOnSave": "Ativa ou desativa a formatação automática ao salvar.",
+  "deno.config.enablePatterns": "As pastas ou arquivos nos quais o Deno deve estar ativado",
   "deno.config.dtsPath": "O caminho para os ficheiros de declaração do TypeScript(.d.ts).",
   "deno.config.importmap": "O caminho para o ficheiro de importação de mapas."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -8,6 +8,7 @@
   "deno.config.packageManager": "用于运行脚本的程序包管理器。",
   "deno.config.alwaysShowStatus": "总是在状态栏显示 Deno 图标。",
   "deno.config.autoFmtOnSave": "是否在保存时进行格式化。",
+  "deno.config.enablePatterns":"应该在其中启用Deno的文件夹或文件",
   "deno.config.dtsPath": "Deno 的类型声明文件(.d.ts)路径。",
   "deno.config.importmap": "import maps 文件的路径。"
 }


### PR DESCRIPTION
# Overview

This PR adds a `deno.enablePatterns` config option that lets you specify particular paths or folders where the extension is enabled. This is useful for projects that contain both Node code and Deno code, such as the `vscode_deno` repo itself. This relates to #87 

Example usage:
```json
{
  "deno.enablePatterns": ["packages/deno/**", "*.deno.ts"]
}
```

Each item in the array matches a regex and only one item needs to match to enable the extension on that file. 

## Disclaimer

This is more of a suggestion. Totally understand if this is the wrong naming convention, or the wrong way to go about this. 

## Testing Done

I've played around with this in a number of different configurations in [this example repo I setup](https://github.com/Flaque/deno_ext_example). Though it might be a good idea for someone else to play around with it. 


