### PR TITLE
add 2 snippets: impstd & importstd and import std module url completion

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -2,6 +2,10 @@
 
 import * as vscode from "vscode";
 import * as lsp from "vscode-languageclient";
+import {
+  ExecuteCommandRequest,
+  RevealOutputChannelOn,
+} from "vscode-languageclient";
 
 /**
  * Represent a vscode command with an ID and an impl function `execute`.
@@ -25,15 +29,39 @@ function restartDenoServer(client: lsp.LanguageClient): Command {
   };
 }
 
+function clearComplementationCache(ctx: vscode.ExtensionContext): Command {
+  return {
+    id: "deno.clearComplementationCache",
+    async execute() {
+      try {
+        let keys = await ctx.globalState.get("keys");
+        await ctx.globalState.update("version", undefined);
+        if (Array.isArray(keys)) {
+          await keys.forEach(async (it) =>
+            await ctx.globalState.update(it, undefined)
+          );
+        }
+        vscode.window.showInformationMessage("Clear success!");
+      } catch (e) {
+        vscode.window.showErrorMessage("Clear faild");
+      }
+      return { dispose() {} };
+    },
+  };
+}
+
 /**
  * Register all supported vscode commands for the Deno extension.
  * @param client LSP language client
+ * @param ctx  VSCode extension context
  */
 export function registerCommands(
   client: lsp.LanguageClient,
+  ctx: vscode.ExtensionContext,
 ): vscode.Disposable[] {
   const commands: Command[] = [
     restartDenoServer(client),
+    clearComplementationCache(ctx),
   ];
 
   const disposables = commands.map((command) => {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -406,7 +406,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Push the disposable to the context's subscriptions so that the
   // client can be deactivated on extension deactivation
-  context.subscriptions.push(...registerCommands(client), client.start());
+  context.subscriptions.push(
+    ...registerCommands(client, context),
+    client.start(),
+  );
 
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor(async (editor) => {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -454,7 +454,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
       documentSelector,
-      new CompletionProvider(),
+      new CompletionProvider(context),
       ...triggerWord,
     ),
   );

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -316,7 +316,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     showStatusBarItem(
       isTypeScriptDocument(editor.document) ||
-      isJavaScriptDocument(editor.document),
+        isJavaScriptDocument(editor.document),
     );
   }
 
@@ -446,15 +446,21 @@ export async function activate(context: vscode.ExtensionContext) {
   // activate the mod helper
   const documentSelector: vscode.DocumentSelector = [
     { language: "javascript" },
-    { language: "typescript" }
-  ]
+    { language: "typescript" },
+  ];
 
-  const triggerWord = ["@", "/"]
+  const triggerWord = ["@", "/"];
 
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(documentSelector, new CompletionProvider(), ...triggerWord));
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      documentSelector,
+      new CompletionProvider(),
+      ...triggerWord,
+    ),
+  );
 }
 
-export function deactivate() { }
+export function deactivate() {}
 
 /** synchronize configuration with typescript-deno-plugin */
 function synchronizeConfiguration(api: any) {
@@ -514,8 +520,8 @@ async function promptForNodeJsProject(): Promise<void> {
       localize(
         "message.maybe_nodejs_project",
         "A package.json file is detected in the project. " +
-        "This project may be a Node.js project. " +
-        "Do you want to disable this extension?",
+          "This project may be a Node.js project. " +
+          "Do you want to disable this extension?",
       ),
       disable,
       cancel,

--- a/client/src/mod_helpers.ts
+++ b/client/src/mod_helpers.ts
@@ -130,7 +130,8 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
       if (!Array.isArray(keys)) {
         this.ext_ctx.globalState.update("keys", [key]);
       } else {
-        this.ext_ctx.globalState.update("keys", keys.push(key));
+        keys.push(key);
+        this.ext_ctx.globalState.update("keys", keys);
       }
       this.ext_ctx.globalState.update(
         key,

--- a/client/src/mod_helpers.ts
+++ b/client/src/mod_helpers.ts
@@ -13,15 +13,27 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
 
     if (/import.+?from\W+['"].*?['"]/.test(lineText)) {
       // We're at import statement line
-      const gh_baseurl = 'https://api.github.com/repos/denoland/deno/contents/std?ref='
-      const importUrl = lineText.match(/.*?['"](\w+:\/\/)(?<domain>.*?)\/(?<lib>\w+)(@(?<ver>[\d.]+))?\/(?<path>.*?)['"]/).groups;
-      const [domain, lib, ver, path] = [importUrl['domain'], importUrl['lib'], importUrl['ver'], importUrl['path']]
-      if (domain === 'deno.land' && lib === 'std') {
+      const gh_baseurl =
+        "https://api.github.com/repos/denoland/deno/contents/std?ref=";
+      const importUrl = lineText.match(
+        /.*?['"](\w+:\/\/)(?<domain>.*?)\/(?<lib>\w+)(@(?<ver>[\d.]+))?\/(?<path>.*?)['"]/,
+      ).groups;
+      const [domain, lib, ver, path] = [
+        importUrl["domain"],
+        importUrl["lib"],
+        importUrl["ver"],
+        importUrl["path"],
+      ];
+      if (domain === "deno.land" && lib === "std") {
         let result = await list_std(ver, path);
-        let entrys = path.split('/')
+        let entrys = path.split("/");
         let entry = entrys[entrys.length - 1];
         return result
-          .filter((it) => it.type === "dir" || (it.type === "file" && it.name.endsWith(".ts") && !it.name.endsWith("_test.ts")))
+          .filter((it) =>
+            it.type === "dir" ||
+            (it.type === "file" && it.name.endsWith(".ts") &&
+              !it.name.endsWith("_test.ts"))
+          )
           .filter((it) => !it.name.startsWith("_")) // exclude fodler or file start with _
           .filter((it) => entry.length === 0 || it.name.startsWith(entry))
           .map((it) => new vscode.CompletionItem(it.name));
@@ -32,25 +44,28 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
 }
 
 interface GH_Entries {
-  name: string,
-  type: string,
-  url: string
+  name: string;
+  type: string;
+  url: string;
 }
 
 interface GH_Result {
-  entries: Array<GH_Entries>
+  entries: Array<GH_Entries>;
 }
 
-async function list_std(ver: string = "master", path: string = ""): Promise<Array<GH_Entries>> {
+async function list_std(
+  ver: string = "master",
+  path: string = "",
+): Promise<Array<GH_Entries>> {
   // TODO: cache the result
 
   let url = "https://api.github.com/repos/denoland/deno/contents/std";
   if (ver === "master") {
-    url = `${url}/${path}?ref=${ver}`
+    url = `${url}/${path}?ref=${ver}`;
   } else {
-    url = `${url}/${path}?ref=std/${ver}`
+    url = `${url}/${path}?ref=std/${ver}`;
   }
-  let result: Array<Object> = (<GH_Result>await got(url, {
+  let result: Array<Object> = (<GH_Result> await got(url, {
     "headers": {
       "accept": "application/vnd.github.v3.object",
       "accept-language": "en-US,en;q=0.9",

--- a/client/src/mod_helpers.ts
+++ b/client/src/mod_helpers.ts
@@ -1,8 +1,14 @@
 import * as vscode from "vscode";
-import { CompletionItemKind } from "vscode-languageclient";
+import { CompletionItemKind, CompletionItem } from "vscode-languageclient";
 import got from "got";
+import { realpath } from "fs";
 
 export class CompletionProvider implements vscode.CompletionItemProvider {
+  ext_ctx: vscode.ExtensionContext;
+  constructor(ext_ctx: vscode.ExtensionContext) {
+    this.ext_ctx = ext_ctx;
+  }
+
   public async provideCompletionItems(
     document: vscode.TextDocument,
     position: vscode.Position,
@@ -25,9 +31,13 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
         importUrl["path"],
       ];
       if (domain === "deno.land" && lib === "std") {
-        let result = await list_std(ver, path);
-        let entrys = path.split("/");
-        let entry = entrys[entrys.length - 1];
+        let entrys = path?.split("/") ?? [];
+        let entry = entrys.splice(-1, 1)[0];
+        let realPath = "";
+        if (entrys.length > 0) {
+          realPath += entrys.join("/") + "/";
+        }
+        let result = await this.list_std(ver, realPath);
         return result
           .filter((it) =>
             it.type === "dir" ||
@@ -35,11 +45,57 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
               !it.name.endsWith("_test.ts"))
           )
           .filter((it) => !it.name.startsWith("_")) // exclude fodler or file start with _
-          .filter((it) => entry.length === 0 || it.name.startsWith(entry))
-          .map((it) => new vscode.CompletionItem(it.name));
+          .filter((it) =>
+            typeof entry === "undefined" ||
+            (entry.length === 0 || it.name.startsWith(entry))
+          )
+          .map((it) =>
+            new vscode.CompletionItem(
+              it.name,
+              it.type === "dir"
+                ? CompletionItemKind.Folder
+                : CompletionItemKind.File,
+            )
+          );
       }
       return undefined;
     }
+  }
+
+  async list_std(
+    ver: string = "master",
+    path: string = "",
+  ): Promise<Array<GH_Entries>> {
+    let cache = <Array<GH_Entries> | undefined> this.ext_ctx.globalState.get(
+      `std@${ver}/${path}`,
+    );
+    if (cache !== undefined && Array.isArray(cache)) {
+      return cache;
+    }
+
+    let url = "https://api.github.com/repos/denoland/deno/contents/std";
+    if (ver === "master") {
+      url = `${url}/${path}?ref=${ver}`;
+    } else {
+      url = `${url}/${path}?ref=std/${ver}`;
+    }
+    let result: Array<GH_Entries> = (<GH_Result> await got(url, {
+      "headers": {
+        "accept": "application/vnd.github.v3.object",
+        "accept-language": "en-US,en;q=0.9",
+      },
+      "method": "GET",
+    }).json())?.entries;
+
+    // cache it
+    this.ext_ctx.globalState.update(
+      `std@${ver}/${path}`,
+      result.map((it) =>
+        <GH_Entries> { name: it.name, type: it.type, url: it.url }
+      ),
+    );
+
+    return result as Array<GH_Entries>;
   }
 }
 
@@ -51,27 +107,4 @@ interface GH_Entries {
 
 interface GH_Result {
   entries: Array<GH_Entries>;
-}
-
-async function list_std(
-  ver: string = "master",
-  path: string = "",
-): Promise<Array<GH_Entries>> {
-  // TODO: cache the result
-
-  let url = "https://api.github.com/repos/denoland/deno/contents/std";
-  if (ver === "master") {
-    url = `${url}/${path}?ref=${ver}`;
-  } else {
-    url = `${url}/${path}?ref=std/${ver}`;
-  }
-  let result: Array<Object> = (<GH_Result> await got(url, {
-    "headers": {
-      "accept": "application/vnd.github.v3.object",
-      "accept-language": "en-US,en;q=0.9",
-    },
-    "method": "GET",
-  }).json())?.entries;
-
-  return result as Array<GH_Entries>;
 }

--- a/client/src/mod_helpers.ts
+++ b/client/src/mod_helpers.ts
@@ -1,0 +1,62 @@
+import * as vscode from "vscode";
+import { CompletionItemKind } from "vscode-languageclient";
+import got from "got";
+
+export class CompletionProvider implements vscode.CompletionItemProvider {
+  public async provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken,
+    context: vscode.CompletionContext,
+  ): Promise<vscode.CompletionItem[] | undefined> {
+    let lineText = document.lineAt(position).text;
+
+    if (/import.+?from\W+['"].*?['"]/.test(lineText)) {
+      // We're at import statement line
+      const gh_baseurl = 'https://api.github.com/repos/denoland/deno/contents/std?ref='
+      const importUrl = lineText.match(/.*?['"](\w+:\/\/)(?<domain>.*?)\/(?<lib>\w+)(@(?<ver>[\d.]+))?\/(?<path>.*?)['"]/).groups;
+      const [domain, lib, ver, path] = [importUrl['domain'], importUrl['lib'], importUrl['ver'], importUrl['path']]
+      if (domain === 'deno.land' && lib === 'std') {
+        let result = await list_std(ver, path);
+        let entrys = path.split('/')
+        let entry = entrys[entrys.length - 1];
+        return result
+          .filter((it) => it.type === "dir" || (it.type === "file" && it.name.endsWith(".ts") && !it.name.endsWith("_test.ts")))
+          .filter((it) => !it.name.startsWith("_")) // exclude fodler or file start with _
+          .filter((it) => entry.length === 0 || it.name.startsWith(entry))
+          .map((it) => new vscode.CompletionItem(it.name));
+      }
+      return undefined;
+    }
+  }
+}
+
+interface GH_Entries {
+  name: string,
+  type: string,
+  url: string
+}
+
+interface GH_Result {
+  entries: Array<GH_Entries>
+}
+
+async function list_std(ver: string = "master", path: string = ""): Promise<Array<GH_Entries>> {
+  // TODO: cache the result
+
+  let url = "https://api.github.com/repos/denoland/deno/contents/std";
+  if (ver === "master") {
+    url = `${url}/${path}?ref=${ver}`
+  } else {
+    url = `${url}/${path}?ref=std/${ver}`
+  }
+  let result: Array<Object> = (<GH_Result>await got(url, {
+    "headers": {
+      "accept": "application/vnd.github.v3.object",
+      "accept-language": "en-US,en;q=0.9",
+    },
+    "method": "GET",
+  }).json())?.entries;
+
+  return result as Array<GH_Entries>;
+}

--- a/client/src/mod_helpers.ts
+++ b/client/src/mod_helpers.ts
@@ -124,12 +124,22 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
     }).json())?.entries;
 
     // cache it
-    this.ext_ctx.globalState.update(
-      `std@${ver}/${path}`,
-      result.map((it) =>
-        <GH_Entry> { name: it.name, type: it.type, url: it.url }
-      ),
-    );
+    let key = `std@${ver}/${path}`;
+    let cache_check = this.ext_ctx.globalState.get(key);
+    let keys = this.ext_ctx.globalState.get("keys");
+    if (cache_check === undefined) {
+      if (!Array.isArray(keys)) {
+        this.ext_ctx.globalState.update("keys", [key]);
+      } else {
+        this.ext_ctx.globalState.update("keys", keys.push(key));
+      }
+      this.ext_ctx.globalState.update(
+        key,
+        result.map((it) =>
+          <GH_Entry> { name: it.name, type: it.type, url: it.url }
+        ),
+      );
+    }
 
     return result as Array<GH_Entry>;
   }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
         "command": "deno.disable",
         "title": "%deno.command.disable%",
         "category": "Deno"
+      },
+      {
+        "command": "deno.clearComplementationCache",
+        "title": "%deno.command.clearImportStdComplementationCache%",
+        "category": "Deno"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
+    "got": "^11.5.1",
     "typescript-deno-plugin": "^1.29.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -140,6 +140,16 @@
         "fileMatch": "denorc.*.json",
         "url": "./schemas/denorc.schema.json"
       }
+    ],
+    "snippets": [
+      {
+        "language": "javascript",
+        "path": "snippets/snippets.json"
+      },
+      {
+        "language": "typescript",
+        "path": "snippets/snippets.json"
+      }
     ]
   },
   "main": "./client/out/extension",

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,5 +10,6 @@
   "deno.config.autoFmtOnSave": "Turns auto format on save on or off.",
   "deno.config.dtsPath": "The Path of TypeScript declaration file(.d.ts).",
   "deno.config.importmap": "The Path of import maps.",
-  "deno.config.unstable": "Enable Deno unstable features."
+  "deno.config.unstable": "Enable Deno unstable features.",
+  "deno.command.clearImportStdComplementationCache": "Clear url complementation cache of the import std feature "
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -9,5 +9,6 @@
   "deno.config.alwaysShowStatus": "总是在状态栏显示 Deno 图标。",
   "deno.config.autoFmtOnSave": "是否在保存时进行格式化。",
   "deno.config.dtsPath": "Deno 的类型声明文件(.d.ts)路径。",
-  "deno.config.importmap": "import maps 文件的路径。"
+  "deno.config.importmap": "import maps 文件的路径。",
+  "deno.command.clearImportStdComplementationCache": "清除import标准库url补全缓存"
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,0 +1,14 @@
+{
+    "Import std": {
+        "scope": "javascript,typescript",
+        "prefix": "importstd",
+        "body": "import ${3|foo,{},* as |} from 'https://deno.land/std@$1/$2';$0",
+        "description": "This snippet code is for deno only, it is for import std module conveniently"
+    },
+    "Imp std": {
+        "scope": "javascript,typescript",
+        "prefix": "impstd",
+        "body": "import {$3} from 'https://deno.land/std@$1/$2';$0",
+        "description": "This snippet code is for deno only, it is for import std module conveniently"
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,28 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sindresorhus/is@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-3.0.0.tgz#78fabc5e295adb6e1ef57eaafe4cc5d7aa35b183"
+  integrity sha512-kqA5I6Yun7PBHk8WN9BBP1c7FfN2SrD05GuVSEYPqDb4nerv7HqYfgBfMIKmT/EuejURkJKLZuLyGKGs6WEG9w==
+
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
+  integrity sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==
+  dependencies:
+    defer-to-connect "^2.0.0"
+
+"@types/cacheable-request@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
+  integrity sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "*"
+    "@types/node" "*"
+    "@types/responselike" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -68,6 +90,18 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/http-cache-semantics@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
+  integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
+
+"@types/keyv@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
+  integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/node@*":
   version "13.13.5"
@@ -83,6 +117,13 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/responselike@*", "@types/responselike@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/vscode@1.40.0":
   version "1.40.0"
@@ -203,6 +244,24 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.npm.taobao.org/buffer-crc32/download/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
+cacheable-lookup@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz#049fdc59dffdd4fc285e8f4f82936591bd59fec3"
+  integrity sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w==
+
+cacheable-request@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.1.tgz#062031c2856232782ed694a257fa35da93942a58"
+  integrity sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
+    responselike "^2.0.0"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -280,6 +339,13 @@ clone-deep@^0.2.4:
     kind-of "^3.0.2"
     lazy-cache "^1.0.3"
     shallow-clone "^0.1.2"
+
+clone-response@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
+  dependencies:
+    mimic-response "^1.0.0"
 
 clone@^1.0.2:
   version "1.0.4"
@@ -391,6 +457,13 @@ debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -402,6 +475,11 @@ defaults@^1.0.3:
   integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
+
+defer-to-connect@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.0.tgz#83d6b199db041593ac84d781b5222308ccf4c2c1"
+  integrity sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==
 
 denodeify@^1.2.1:
   version "1.2.1"
@@ -603,7 +681,7 @@ get-own-enumerable-property-symbols@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
   integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
 
-get-stream@^5.0.0:
+get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
   integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
@@ -621,6 +699,23 @@ glob@^7.0.6, glob@^7.1.2, glob@^7.1.3:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+got@^11.5.1:
+  version "11.5.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.5.1.tgz#bf098a270fe80b3fb88ffd5a043a59ebb0a391db"
+  integrity sha512-reQEZcEBMTGnujmQ+Wm97mJs/OK6INtO6HmLI+xt3+9CvnRwWjXutUvb2mqr+Ao4Lu05Rx6+udx9sOQAmExMxA==
+  dependencies:
+    "@sindresorhus/is" "^3.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.1"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.0"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -644,6 +739,11 @@ htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
+http-cache-semantics@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
+  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+
 http-proxy-agent@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
@@ -651,6 +751,14 @@ http-proxy-agent@^2.1.0:
   dependencies:
     agent-base "4"
     debug "3.1.0"
+
+http2-wrapper@^1.0.0-beta.5.0:
+  version "1.0.0-beta.5.2"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz#8b923deb90144aea65cf834b016a340fc98556f3"
+  integrity sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
 
 https-proxy-agent@^2.2.4:
   version "2.2.4"
@@ -781,10 +889,22 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+
+keyv@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.1.tgz#9fe703cb4a94d6d11729d320af033307efd02ee6"
+  integrity sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==
+  dependencies:
+    json-buffer "3.0.1"
 
 kind-of@^2.0.1:
   version "2.0.1"
@@ -895,6 +1015,11 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+
 magic-string@^0.25.2:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -950,6 +1075,16 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-response@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -984,6 +1119,11 @@ normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+normalize-url@^4.1.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
+  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
 npm-run-path@^4.0.0:
   version "4.0.1"
@@ -1040,6 +1180,11 @@ osenv@^0.1.3:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+p-cancelable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.0.0.tgz#4a3740f5bdaf5ed5d7c3e34882c6fb5d6b266a6e"
+  integrity sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -1162,6 +1307,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
 read@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npm.taobao.org/read/download/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
@@ -1183,6 +1333,11 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
+resolve-alpn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.0.0.tgz#745ad60b3d6aff4b4a48e01b8c0bdc70959e0e8c"
+  integrity sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -1194,6 +1349,13 @@ resolve@^1.11.0:
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
+
+responselike@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
+  integrity sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 restore-cursor@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
$0: denotes the final cursor position
$1..n: tabstops in sequence

impstd =>  `import {$3} from 'https://deno/std@$1/$2';$0"`
importstd => `import (foo|{foo}| * as foo) from 'https://deno/std@$1/$2';$0"`


- [x]  fetch std library information dynamically  from github
- [x]  import completion
- [x]  std version completion
- [x]  cache the result
- [x]  add command to clear the cache to allow user to refresh local import std cache

## Screenshots: 
![image](https://user-images.githubusercontent.com/15936231/88250129-2e997580-ccd9-11ea-8267-6f980cdb8f41.png)
![image](https://user-images.githubusercontent.com/15936231/88250297-b3848f00-ccd9-11ea-958e-f96409423199.png)
![image](https://user-images.githubusercontent.com/15936231/88253647-37904400-cce5-11ea-9543-f3d39c86c7e6.png)
![image](https://user-images.githubusercontent.com/15936231/88255431-fbf87880-ccea-11ea-928f-6d9d0d007ae9.png)
![image](https://user-images.githubusercontent.com/15936231/88255443-0155c300-cceb-11ea-8588-c350bacd4acd.png)


Implementation of #114 