### PR TITLE
re-added deno fmt on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ Note the VS Code based configuration overrides the `tsconfig` configuration.
 
 - `deno.importmap` - The Path of import maps. Default is `null`.
 
-- `deno.autoFmtOnSave` - Turns auto format on save on or off. Default is `false`. (**Not implemented**)
-
 ## Commands
 
 This extension contributes the following commands to the Command palette.


### PR DESCRIPTION
A First pass implementation of getting `fmtOnSave` to work again. Not 100% sure how to handle any errors from the `execa` call.