### PR TITLE
Include deno.enablePatterns on config schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
           "default": false,
           "description": "%deno.config.enabled%"
         },
+        "deno.enablePatterns": {
+          "type": ["array"],
+          "description": "%deno.config.enablePatterns%"
+        },
         "deno.alwaysShowStatus": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION

A new config option, `deno.enablePatterns`, was added in #92. The [config schema](https://code.visualstudio.com/api/references/contribution-points#contributes.configuration) wasn't added, probably because there's no UI editor for "array" type. However, it's still worth defining.

1. To avoid this confusing message:
<img width="283" alt="Screen Shot 2020-08-09 at 5 31 18 PM" src="https://user-images.githubusercontent.com/21505/89745064-2590fe00-da66-11ea-96df-f5345f9f60dc.png">

2. To get an indication in the Settings UI that the key exists and can be edited in the JSON:
> Other types, such as object and array, aren't exposed directly in the settings UI, and can only be modified by editing the JSON directly. Instead of controls for editing them, users will see a link to Edit in settings.json as shown in the screenshot above.