### PR TITLE
reimplement deno.enablePatterns feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ const M = array.getMonoid<number>();
 console.log("concat Array", M.concat([1, 2], [2, 3]));
 ```
 
+- `deno.enablePatterns` - An array of regexes that matches files Deno should be enabled on. Default is `["*"]` (matches all files). Paths are relative to the workspaces directory, so for example `["packages/"']` will look for the `packages` folder in your project.
+
 </details>
 
 ## Usage

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -234,6 +234,20 @@ export class Extension {
               if (!context.diagnostics || context.diagnostics.length === 0) {
                 return [];
               }
+
+              // If deno.enablePatterns is specified and this file doesn't
+              // match a path, then disable Deno.
+              const paths = (config.get("deno.enablePatterns") || ["*"]) as string[];
+              if (paths && paths.length) { 
+                const localFileName = document.fileName
+                  .replace(workspace.rootPath, "");
+                const matchesPath = paths
+                  .findIndex((p) => RegExp(p).test(localFileName));
+                if (!matchesPath) {
+                  return [];
+                }
+              }
+
               const denoDiagnostics: Diagnostic[] = [];
               for (const diagnostic of context.diagnostics) {
                 if (diagnostic.source === "Deno Language Server") {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -383,16 +383,13 @@ Executable ${this.denoInfo.executablePath}`;
     if (!config.enable) return false;
     if (!config.enablePatterns) return true;
 
-    // If the file isn't part of a workspace, ignore enablePatterns
-    const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
-    if (!workspaceFolder) return true;
-
     // Check that document matches an enablePattern
-    const rootPath = workspaceFolder.uri.fsPath;
-    const localFileName = document.fileName
-      .replace(rootPath, "");
+    const relativeFilepath = workspace.asRelativePath(
+      document.uri.fsPath,
+      false
+    );
     const isMatching = config.enablePatterns
-      .some((p) => RegExp(p).test(localFileName));
+      .some((p) => RegExp(p).test(relativeFilepath));
 
     return isMatching;
   }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -236,9 +236,9 @@ export class Extension {
                 return [];
               }
 
-              // If deno.enablePatterns is specified and this file doesn't
-              // match a path, then disable Deno.
-              if (enablePatterns) { 
+              // If we're in a workspace with enablePatterns, check that
+              // the document matches a pattern.
+              if (workspace.rootPath && enablePatterns) { 
                 const localFileName = document.fileName
                   .replace(workspace.rootPath, "");
                 const matchesPath = enablePatterns

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -256,7 +256,7 @@ export class Extension {
               token,
               next
             ) => {
-              if (!this.getConfiguration(document.uri).enable) {
+              if (!this.enabledFor(document)) {
                 return [];
               }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -227,7 +227,8 @@ export class Extension {
           progressOnInitialization: true,
           middleware: {
             provideCodeActions: (document, range, context, token, next) => {
-              if (!this.getConfiguration(document.uri).enable) {
+              const {enable, enablePatterns} = this.getConfiguration(document.uri);
+              if (!enable) {
                 return [];
               }
               // do not ask server for code action when the diagnostic isn't from deno
@@ -237,11 +238,10 @@ export class Extension {
 
               // If deno.enablePatterns is specified and this file doesn't
               // match a path, then disable Deno.
-              const paths = (config.get("deno.enablePatterns") || ["*"]) as string[];
-              if (paths && paths.length) { 
+              if (enablePatterns) { 
                 const localFileName = document.fileName
                   .replace(workspace.rootPath, "");
-                const matchesPath = paths
+                const matchesPath = enablePatterns
                   .findIndex((p) => RegExp(p).test(localFileName));
                 if (!matchesPath) {
                   return [];

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -238,12 +238,14 @@ export class Extension {
 
               // If we're in a workspace with enablePatterns, check that
               // the document matches a pattern.
-              if (workspace.rootPath && enablePatterns) { 
+              const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
+              if (workspaceFolder && enablePatterns) { 
+                const rootPath = workspaceFolder.uri.fsPath;
                 const localFileName = document.fileName
-                  .replace(workspace.rootPath, "");
-                const matchesPath = enablePatterns
-                  .findIndex((p) => RegExp(p).test(localFileName));
-                if (!matchesPath) {
+                  .replace(rootPath, "");
+                const isMatching = enablePatterns
+                  .some((p) => RegExp(p).test(localFileName));
+                if (!isMatching) {
                   return [];
                 }
               }

--- a/core/configuration.ts
+++ b/core/configuration.ts
@@ -11,12 +11,14 @@ export const DenoPluginConfigurationField: (keyof ConfigurationField)[] = [
   "enable",
   "unstable",
   "import_map",
+  "enablePatterns"
 ];
 
 export type ConfigurationField = {
   enable?: boolean;
   unstable?: boolean;
   import_map?: string | null;
+  enablePatterns?: string[];
 };
 
 interface ConfigurationInterface {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,15 @@
             false
           ]
         },
+        "deno.enablePatterns": {
+          "type": ["array"],
+          "markdownDescription": "Array of RegEx patterns for workspace files in which to enable Deno.",
+          "scope": "resource",
+          "examples": [
+            ["\\.deno\\.ts$"],
+            ["cli\/", "build\/"]
+          ]          
+        },
         "deno.import_map": {
           "type": "string",
           "default": null,


### PR DESCRIPTION
Attempting to add https://github.com/denoland/vscode_deno/pull/92/ after it was [removed from master](https://github.com/denoland/vscode_deno/pull/126#issuecomment-674508634). 

However, in my testing it's not working as expected. Even documents that don't match are getting Deno errors when `enabled` is true. For example,
<img width="714" alt="Screen Shot 2020-08-21 at 2 48 06 PM" src="https://user-images.githubusercontent.com/21505/90938174-54d83100-e3bd-11ea-8756-cd8ff4930c0d.png">

@Flaque did #92 have this problem?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/denoland/vscode_deno/153)
<!-- Reviewable:end -->
