### PR TITLE
fix: autocomplete supports adding extensions

### DIFF
--- a/core/deno_normalize_import_statement.test.ts
+++ b/core/deno_normalize_import_statement.test.ts
@@ -60,4 +60,19 @@ test("core / deno_normalize_import_statement", () => {
       `import { example } from "https://example.com/foo/bar.ts";`
     )
   ).toEqual(`import { example } from "https://example.com/foo/bar.ts";`);
+
+  expect(
+    normalizeImportStatement(__filename, `import { example } from "./deno";`)
+  ).toEqual(`import { example } from "./deno.ts";`);
+
+  expect(
+    normalizeImportStatement(
+      __filename,
+      `import { example } from "./testdata/file_walker/a";`
+    )
+  ).toEqual(`import { example } from "./testdata/file_walker/a.js";`);
+
+  expect(
+    normalizeImportStatement(__filename, `import { example } from "./none";`)
+  ).toEqual(`import { example } from "./none";`);
 });

--- a/core/util.test.ts
+++ b/core/util.test.ts
@@ -1,4 +1,3 @@
-import path from "path";
 import {
   pathExists,
   pathExistsSync,

--- a/core/util.test.ts
+++ b/core/util.test.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import {
   pathExists,
   pathExistsSync,
@@ -7,6 +8,7 @@ import {
   normalizeFilepath,
   isValidDenoDocument,
   isUntitledDocument,
+  findNonExtensionModule,
 } from "./util";
 
 test("core / util / pathExists", async () => {
@@ -71,4 +73,13 @@ test("core / util / isUntitledDocument", () => {
   expect(isUntitledDocument("./foo")).toBe(false);
   expect(isUntitledDocument("../bar")).toBe(false);
   expect(isUntitledDocument("untitled: ")).toBe(true);
+});
+
+test("core / util / findNonExtensionModule", () => {
+  expect(findNonExtensionModule(__filename, "./deno")).toBe("./deno.ts");
+  expect(findNonExtensionModule(__filename, "./logger")).toBe("./logger.ts");
+  expect(findNonExtensionModule(__filename, "./testdata/file_walker/a")).toBe(
+    "./testdata/file_walker/a.js"
+  );
+  expect(findNonExtensionModule(__filename, "./none")).toBe("./none");
 });

--- a/core/util.ts
+++ b/core/util.ts
@@ -100,7 +100,15 @@ export function findNonExtensionModule(
     return;
   }
 
-  const denoSupportedExtensions = [".ts", ".d.ts", ".js", ".wasm"];
+  const denoSupportedExtensions = [
+    ".ts",
+    ".tsx",
+    ".d.ts",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".wasm",
+  ];
 
   while (denoSupportedExtensions.length) {
     const extension = denoSupportedExtensions.shift();

--- a/core/util.ts
+++ b/core/util.ts
@@ -107,7 +107,6 @@ export function findNonExtensionModule(
     ".js",
     ".jsx",
     ".mjs",
-    ".wasm",
   ];
 
   while (denoSupportedExtensions.length) {


### PR DESCRIPTION
close #138 

Typescript does not add extensions by default for cached modules when import from autocomplete

```diff
- import { foo } from "./bar"
+ import { foo } from "./bar.ts"
```

Now it has been fixed

/cc @ry @bartlomieju 

### before

![2](https://user-images.githubusercontent.com/9758711/91455200-5ff6f980-e8b4-11ea-9eb3-bcd027296aab.gif)

### after

![1](https://user-images.githubusercontent.com/9758711/91454422-84060b00-e8b3-11ea-8a81-47d227ec9e36.gif)

```
 PASS  core/deno_normalize_import_statement.test.ts
 PASS  core/deno_deps.test.ts
 PASS  core/deno_type_hint.test.ts
 PASS  core/cache.test.ts
 PASS  core/import_map.test.ts
 PASS  core/module_resolver.test.ts
 PASS  core/cache_map.test.ts
 PASS  core/file_walker.test.ts
 PASS  core/extension.test.ts
 PASS  core/configuration.test.ts
 PASS  core/deno_cache.test.ts
 PASS  core/deno.test.ts
 PASS  core/util.test.ts
 PASS  core/hash_meta.test.ts
------------------------------------|---------|----------|---------|---------|-------------------
File                                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------------------------|---------|----------|---------|---------|-------------------
All files                           |     100 |      100 |     100 |     100 |                   
 cache.ts                           |     100 |      100 |     100 |     100 |                   
 cache_map.ts                       |     100 |      100 |     100 |     100 |                   
 configuration.ts                   |     100 |      100 |     100 |     100 |                   
 deno.ts                            |     100 |      100 |     100 |     100 |                   
 deno_cache.ts                      |     100 |      100 |     100 |     100 |                   
 deno_deps.ts                       |     100 |      100 |     100 |     100 |                   
 deno_normalize_import_statement.ts |     100 |      100 |     100 |     100 |                   
 deno_type_hint.ts                  |     100 |      100 |     100 |     100 |                   
 extension.ts                       |     100 |      100 |     100 |     100 |                   
 file_walker.ts                     |     100 |      100 |     100 |     100 |                   
 hash_meta.ts                       |     100 |      100 |     100 |     100 |                   
 import_map.ts                      |     100 |      100 |     100 |     100 |                   
 module_resolver.ts                 |     100 |      100 |     100 |     100 |                   
 util.ts                            |     100 |      100 |     100 |     100 |                   
------------------------------------|---------|----------|---------|---------|-------------------
```
