### PR TITLE
Fix #158 handle properly dependencies cache when deno/deps does not exists

### DIFF
--- a/core/deno_deps.ts
+++ b/core/deno_deps.ts
@@ -31,7 +31,16 @@ export type Range = {
 export async function getAllDenoCachedDeps(): Promise<Deps[]> {
   const depsRootDir = getDenoDepsDir();
   const deps: Deps[] = [];
-  const protocols = await fs.readdir(depsRootDir);
+  let protocols: string[] = [];
+
+  try {
+    protocols = await fs.readdir(depsRootDir);
+  } catch (error) {
+    //deno/deps directory does not exists
+    if (error.code === "ENOENT") {
+      return deps;
+    }
+  }
 
   await Promise.all(
     protocols.map(async (protocol) => {


### PR DESCRIPTION
It handles ENOENT error thrown by the getAllDenoCachedDeps function when
the deno/deps directory does not exists (e.g. a deno fresh install).

Fix #158