### PR TITLE
Add support for URLs with non-default ports

### DIFF
--- a/core/deno_cache.ts
+++ b/core/deno_cache.ts
@@ -125,7 +125,7 @@ export class CacheModule implements DenoCacheModule {
       targetOriginDir = path.join(
         getDenoDepsDir(),
         url.protocol.replace(/:$/, ""), // https: -> https
-        url.hostname + (url.port ? `_PORT${url.port}` : url.port)
+        `${url.hostname}${url.port ? `_PORT${url.port}` : ""}`
       );
     }
     // invalid

--- a/core/deno_cache.ts
+++ b/core/deno_cache.ts
@@ -125,7 +125,7 @@ export class CacheModule implements DenoCacheModule {
       targetOriginDir = path.join(
         getDenoDepsDir(),
         url.protocol.replace(/:$/, ""), // https: -> https
-        url.hostname
+        url.hostname + (url.port ? `_PORT${url.port}` : url.port)
       );
     }
     // invalid

--- a/core/module_resolver.test.ts
+++ b/core/module_resolver.test.ts
@@ -28,6 +28,8 @@ test("core / module_resolver: resolve module from Deno cache", () => {
       "./sub/mod.ts",
       "/esm/mod.ts",
       "https://example.com/esm/mod.ts",
+      "https://example.com:443/esm/mod.ts",
+      "http://localhost:3000/mod.ts",
       "./module_not_exist.ts",
       "https://module.not.exist.com/mod.ts",
     ])
@@ -54,6 +56,25 @@ test("core / module_resolver: resolve module from Deno cache", () => {
       filepath: path.join(
         path.dirname(cacheFilepath),
         "8afd52da760dab7f2deda4b7453197f50421f310372c5da3f3847ffd062fa1cf"
+      ),
+    },
+    {
+      extension: ".ts",
+      origin: "https://example.com:443/esm/mod.ts",
+      filepath: path.join(
+        path.dirname(cacheFilepath),
+        "8afd52da760dab7f2deda4b7453197f50421f310372c5da3f3847ffd062fa1cf"
+      ),
+    },
+    {
+      extension: ".ts",
+      origin: "http://localhost:3000/mod.ts",
+      filepath: path.join(
+        denoDir,
+        "deps",
+        "http",
+        "localhost_PORT3000",
+        "51a61f14fdad404fd2c9187363be7846d6d3b84a2b8697b9bd50c60d4509ab60"
       ),
     },
     undefined,

--- a/core/module_resolver.ts
+++ b/core/module_resolver.ts
@@ -75,7 +75,7 @@ export class ModuleResolver implements ModuleResolverInterface {
     const originDir = path.join(
       getDenoDepsDir(),
       url.protocol.replace(/:$/, ""), // https: -> https
-      url.hostname
+      `${url.hostname}${url.port ? `_PORT${url.port}` : ""}`, // hostname.xyz:3000 -> hostname.xyz_PORT3000
     );
 
     const hash = hashURL(url);

--- a/core/module_resolver.ts
+++ b/core/module_resolver.ts
@@ -75,7 +75,7 @@ export class ModuleResolver implements ModuleResolverInterface {
     const originDir = path.join(
       getDenoDepsDir(),
       url.protocol.replace(/:$/, ""), // https: -> https
-      `${url.hostname}${url.port ? `_PORT${url.port}` : ""}`, // hostname.xyz:3000 -> hostname.xyz_PORT3000
+      `${url.hostname}${url.port ? `_PORT${url.port}` : ""}` // hostname.xyz:3000 -> hostname.xyz_PORT3000
     );
 
     const hash = hashURL(url);

--- a/core/testdata/deno_dir_manifest/deps/http/localhost_PORT3000/51a61f14fdad404fd2c9187363be7846d6d3b84a2b8697b9bd50c60d4509ab60.metadata.json
+++ b/core/testdata/deno_dir_manifest/deps/http/localhost_PORT3000/51a61f14fdad404fd2c9187363be7846d6d3b84a2b8697b9bd50c60d4509ab60.metadata.json
@@ -1,0 +1,4 @@
+{
+  "headers": {},
+  "url": "http://localhost:3000/mod.ts"
+}


### PR DESCRIPTION
Ref. Deno source: https://github.com/denoland/deno/blob/2da084058397efd6f517ba98c9882760ec0a7bd6/cli/disk_cache.rs#L55

Ref. previous PR: https://github.com/justjavac/typescript-deno-plugin/pull/63

This adds support for port numbers in remote module resolution. I didn't see any places that would support a test for this, so please test with a local file server before merging.

I think this should resolve #171.