### PR TITLE
v2.1.1

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -2,6 +2,10 @@
 
 Releases of the extension can be downloaded from [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno).
 
+### [v2.1.1](https://github.com/denoland/vscode_deno/compare/v2.1.0...v2.1.1) / 2020.09.04
+
+- fix: typescript not found error (#177)
+
 ### [v2.1.0](https://github.com/denoland/vscode_deno/compare/v2.0.16...v2.1.0) / 2020.09.04
 
 - feat: IntelliSense support for std and deno.land/x imports (#172)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-deno",
   "displayName": "Deno",
   "description": "Deno support for VSCode",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "publisher": "denoland",
   "icon": "deno.png",
   "galleryBanner": {

--- a/typescript-deno-plugin/package.json
+++ b/typescript-deno-plugin/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/deep-equal": "1.0.1",
-    "@types/json5": "0.0.30"
+    "@types/json5": "0.0.30",
+    "typescript": "4.0.2"
   }
 }


### PR DESCRIPTION
Fixes this error:
```
Error: Cannot find module 'typescript'
Require stack:
- /home/lucacasonato/.vscode/extensions/denoland.vscode-deno-2.1.0/server/out/server/src/dependency_tree.js
- /home/lucacasonato/.vscode/extensions/denoland.vscode-deno-2.1.0/server/out/server/src/server.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:764:15)
    at Module._load (internal/modules/cjs/loader.js:669:27)
    at Module._load (electron/js2c/asar.js:717:26)
    at Function.Module._load (electron/js2c/asar.js:717:26)
    at Module.require (internal/modules/cjs/loader.js:822:19)
    at require (internal/modules/cjs/helpers.js:68:18)
    at Object.<anonymous> (/home/lucacasonato/.vscode/extensions/denoland.vscode-deno-2.1.0/server/out/server/src/dependency_tree.js:32:25)
    at Module._compile (internal/modules/cjs/loader.js:927:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:939:10)
    at Module.load (internal/modules/cjs/loader.js:782:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/lucacasonato/.vscode/extensions/denoland.vscode-deno-2.1.0/server/out/server/src/dependency_tree.js',
    '/home/lucacasonato/.vscode/extensions/denoland.vscode-deno-2.1.0/server/out/server/src/server.js'
  ]
}
```