### PR TITLE
build: release vsix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,19 @@ jobs:
       - name: Package
         run: npm run build
 
+      - name: Release
+        if: |
+          startsWith(matrix.os, 'ubuntu') &&
+          github.repository == 'denoland/vscode_deno' &&
+          startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            vscode-deno.vsix
+          draft: true
+
       - name: Publish
         if: |
           startsWith(matrix.os, 'ubuntu') &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,6 @@ jobs:
         with:
           files: |
             vscode-deno.vsix
-          draft: true
 
       - name: Publish
         if: |


### PR DESCRIPTION
This adds the `deno-vscode.vsix` as a release artifact so VS Code based editors that do not have access to the Visual Studio Marketplace (e.g. `theia` and `code-server`) can make use of the extension easily.

Fixes #79 