### PR TITLE
feat: integrate TypeScript project references

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./src",
-    "outDir": "./out"
+    // "baseUrl": "./src",
+    "outDir": "../out/client",
+    "composite": true
   },
-  "include": ["./src", "../core"]
+  // "include": ["./src", "../core"],
+  "references": [
+    {
+      "path": "../core"
+    }
+  ]
 }

--- a/core/file_walker.test.ts
+++ b/core/file_walker.test.ts
@@ -14,7 +14,7 @@ test("core / FileWalker", async () => {
     path.join(TEST_DIR, "file_walker", "exclude", "c.tsx"),
   ];
 
-  const result = [];
+  const result: string[] = [];
 
   for await (const file of walker) {
     expect(typeof file).toBe("string");
@@ -35,7 +35,7 @@ test("core / FileWalker with specified extension name", async () => {
     path.join(TEST_DIR, "file_walker", "exclude", "c.tsx"),
   ];
 
-  const result = [];
+  const result: string[] = [];
 
   for await (const file of walker) {
     expect(typeof file).toBe("string");
@@ -57,7 +57,7 @@ test("core / FileWalker with exclude options", async () => {
     path.join(TEST_DIR, "file_walker", "b.ts"),
   ];
 
-  const result = [];
+  const result: string[] = [];
 
   for await (const file of walker) {
     expect(typeof file).toBe("string");
@@ -81,7 +81,7 @@ test("core / FileWalker ignore hidden file", async () => {
 
   const files = [path.join(TEST_DIR, "file_walker", "b.ts")];
 
-  const result = [];
+  const result: string[] = [];
 
   for await (const file of walker) {
     expect(typeof file).toBe("string");

--- a/core/import_intellisense.ts
+++ b/core/import_intellisense.ts
@@ -9,8 +9,7 @@ import {
 } from "path-to-regexp";
 import * as yup from "yup";
 import { DiskCache } from "./diskcache";
-
-const VERSION = "2.3.3";
+import { version as VERSION } from "../package.json";
 
 export const IMPORT_REG = /^(?<rest>.*?[import|export](.+?from)?.+?['"])(?<url>[0-9a-zA-Z-_@~:/.?#:&=%+]*)/;
 

--- a/core/import_intellisense.ts
+++ b/core/import_intellisense.ts
@@ -9,7 +9,8 @@ import {
 } from "path-to-regexp";
 import * as yup from "yup";
 import { DiskCache } from "./diskcache";
-import { version as VERSION } from "../package.json";
+
+const VERSION = "2.3.3";
 
 export const IMPORT_REG = /^(?<rest>.*?[import|export](.+?from)?.+?['"])(?<url>[0-9a-zA-Z-_@~:/.?#:&=%+]*)/;
 

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../out/core",
+    "composite": true
+  },
+  // "include": ["./*"],
+  "exclude": [
+    // "*.test.ts"
+  ]
+}

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -7,5 +7,10 @@
   // "include": ["./*"],
   "exclude": [
     // "*.test.ts"
+  ],
+  "references": [
+    {
+      "path": "../tsconfig.package.json"
+    }
   ]
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./src",
-    "outDir": "./out"
+    // "baseUrl": "./src",
+    "outDir": "../out/server",
+    "composite": true
   },
-  "include": ["./src", "../core"]
+  // "include": ["./src", "../core"],
+  "references": [
+    {
+      "path": "../core"
+    }
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,5 +17,5 @@
     "resolveJsonModule": true,
     "strictBindCallApply": true
   },
-  "exclude": ["**/*.test.ts"]
+  // "exclude": ["**/*.test.ts"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,5 @@
     "removeComments": true,
     "resolveJsonModule": true,
     "strictBindCallApply": true
-  },
-  // "exclude": ["**/*.test.ts"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,12 +5,8 @@
     // "outDir": "./out",
     "sourceMap": true,
     "strict": true,
-    "esModuleInterop": true,
-    // "baseUrl": "./src",
-    // "composite": true
+    "esModuleInterop": true
   },
-  // "include": ["./src"],
-  // "exclude": ["node_modules", "core/testdata"],
   "files": [],
   "references": [
     { "path": "./client" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,17 +2,20 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es6",
-    "outDir": "./out",
+    // "outDir": "./out",
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "baseUrl": "./src"
+    // "baseUrl": "./src",
+    // "composite": true
   },
-  "include": ["./src"],
-  "exclude": ["node_modules", "core/testdata"],
+  // "include": ["./src"],
+  // "exclude": ["node_modules", "core/testdata"],
+  "files": [],
   "references": [
     { "path": "./client" },
     { "path": "./server" },
-    { "path": "./typescript-deno-plugin" }
+    { "path": "./typescript-deno-plugin" },
+    { "path": "./core" }
   ]
 }

--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"composite": true
+	},
+	"files": ["./package.json"]
+}

--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -1,7 +1,7 @@
 {
-	"extends": "./tsconfig.base.json",
-	"compilerOptions": {
-		"composite": true
-	},
-	"files": ["./package.json"]
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "files": ["./package.json"]
 }

--- a/typescript-deno-plugin/tsconfig.json
+++ b/typescript-deno-plugin/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./src",
-    "outDir": "../node_modules/typescript-deno-plugin/out"
+    // "baseUrl": "./src",
+    "outDir": "../out/typescript-deno-plugin",
+    "composite": true
   },
-  "include": ["./src", "../core"]
+  // "include": ["./src", "../core"],
+  "references": [
+    {
+      "path": "../core"
+    }
+  ]
 }


### PR DESCRIPTION
The use of project references encourages the TypeScript compiler to reuse compiled sources for later compiles. This leads to dramatically quickened build times after the initial run.

To illustrate, the recorded times below showcase warm compiles before and after the changes in the pull request:

```console
$ time npm run compile

> vscode-deno@2.3.3 compile
> tsc -b


real    0m11.002s
user    0m19.640s
sys     0m0.652s
```

```console
$ time npm run compile

> vscode-deno@2.3.3 compile
> tsc -b


real    0m0.528s
user    0m0.388s
sys     0m0.117s
```