### PR TITLE
fix: add step to configure unstable mode

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -514,8 +514,7 @@ Executable ${this.denoInfo.executablePath}`;
         // if you init project, you enable the plugin. NO NEED CHOOSE
         await config.update("enable", true);
         await config.update("lint", setting.lint);
-        // if lint enabled, enable unstable as well
-        await config.update("unstable", setting.lint);
+        await config.update("unstable", setting.unstable);
         window
           .showInformationMessage(
             "Deno is now set up. You can enable and disable settings (like `--unstable`) in the `.vscode/settings.json` file. Before the extension will work you need to reload VS Code.",

--- a/client/src/init_project.ts
+++ b/client/src/init_project.ts
@@ -43,7 +43,8 @@ export async function initProject(): Promise<ProjectSetting> {
       title,
       step: 2,
       totalSteps,
-      placeholder: "Enable unstable mode? Note: unstable mode is required to use deno lint",
+      placeholder:
+        "Enable unstable mode? Note: unstable mode is required to use deno lint",
       items: (["Yes", "No"].map((label) => ({
         label,
       })) as unknown[]) as QuickPickItem[],

--- a/client/src/init_project.ts
+++ b/client/src/init_project.ts
@@ -1,26 +1,26 @@
 import { MultiStepInput } from "./mutistep_helper";
 import { QuickPickItem } from "vscode";
 
-interface State {
+interface State extends Partial<ProjectSetting> {
   title: string;
   step: number;
   totalSteps: number;
-
-  lint: boolean;
 }
 
 export interface ProjectSetting {
   lint: boolean;
+  unstable: boolean;
 }
 
 export async function initProject(): Promise<ProjectSetting> {
   const title = "Init";
+  const totalSteps = 2;
 
   async function lint(input: MultiStepInput, state: Partial<State>) {
     const pick = await input.showQuickPick({
       title,
       step: 1,
-      totalSteps: 1,
+      totalSteps,
       placeholder: "Enable deno lint?",
       items: (["Yes", "No"].map((label) => ({
         label,
@@ -34,13 +34,37 @@ export async function initProject(): Promise<ProjectSetting> {
     } else {
       state.lint = false;
     }
+
+    return (input: MultiStepInput) => unstable(input, state);
   }
 
-  async function collectInputs() {
-    const state = {} as Partial<State>;
+  async function unstable(input: MultiStepInput, state: Partial<State>) {
+    const pick = await input.showQuickPick({
+      title,
+      step: 2,
+      totalSteps,
+      placeholder: "Enable unstable mode? Note: unstable mode is required to use deno lint",
+      items: (["Yes", "No"].map((label) => ({
+        label,
+      })) as unknown[]) as QuickPickItem[],
+      buttons: [],
+      shouldResume: async () => false,
+    });
+
+    if (pick.label === "Yes") {
+      state.unstable = true;
+    } else {
+      state.unstable = false;
+    }
+
+    return;
+  }
+
+  async function collectInputs(): Promise<ProjectSetting> {
+    const state: Partial<State> = {};
     await MultiStepInput.run((input) => lint(input, state));
-    return state as State;
+    return state as ProjectSetting;
   }
 
-  return await collectInputs();
+  return collectInputs();
 }


### PR DESCRIPTION
The pull request adds an additional step to the "deno: Init" command to configure unstable mode based on the user's input.

Fixes #257 