### PR TITLE
fix: include typescript-deno-plugin in vsix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
       "dev": true
     },
     "typescript-deno-plugin": {
-      "version": "file:typescript-deno-plugin",
-      "dev": true
+      "version": "file:typescript-deno-plugin"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -118,9 +118,11 @@
     "watch": "tsc -b -w",
     "postinstall": "cd typescript-deno-plugin && npm i && cd ../client && npm i && cd .."
   },
+  "dependencies": {
+    "typescript-deno-plugin": "./typescript-deno-plugin"
+  },
   "devDependencies": {
     "@types/node": "^14.14.7",
-    "typescript": "^4.0.5",
-    "typescript-deno-plugin": "./typescript-deno-plugin"
+    "typescript": "^4.0.5"
   }
 }

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -157,6 +157,7 @@ class Plugin implements ts.server.PluginModule {
 }
 
 function init(): ts.server.PluginModule {
+  console.log("INIT typescript-deno-plugin");
   return new Plugin();
 }
 


### PR DESCRIPTION
Because it is not currently included, the plugin is not installed in the released VS Code extension, which means double diagnostics.