### PR TITLE
feat: code lens for references

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -3,8 +3,15 @@
 /** Contains handlers for commands that are enabled in Visual Studio Code for
  * the extension. */
 
-import { ExtensionContext, Uri, ViewColumn, window, workspace } from "vscode";
-import { LanguageClient } from "vscode-languageclient";
+import {
+  commands,
+  ExtensionContext,
+  Uri,
+  ViewColumn,
+  window,
+  workspace,
+} from "vscode";
+import { LanguageClient, Location, Position } from "vscode-languageclient";
 import { cache as cacheReq } from "./lsp_extensions";
 
 // deno-lint-ignore no-explicit-any
@@ -28,6 +35,20 @@ export function cache(
     return client.sendRequest(
       cacheReq,
       { textDocument: { uri: activeEditor.document.uri.toString() } },
+    );
+  };
+}
+
+export function showReferences(
+  _content: ExtensionContext,
+  client: LanguageClient,
+): Callback {
+  return (uri: string, position: Position, locations: Location[]) => {
+    commands.executeCommand(
+      "editor.action.showReferences",
+      Uri.parse(uri),
+      client.protocol2CodeConverter.asPosition(position),
+      locations.map(client.protocol2CodeConverter.asLocation),
     );
   };
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -139,6 +139,7 @@ export async function activate(
   // Register any commands.
   const registerCommand = createRegisterCommand(context);
   registerCommand("cache", commands.cache);
+  registerCommand("showReferences", commands.showReferences);
   registerCommand("status", commands.status);
 
   context.subscriptions.push(client.start());

--- a/package.json
+++ b/package.json
@@ -66,6 +66,26 @@
             false
           ]
         },
+        "deno.codeLens.references": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enables or disables the display of code lens information for references of items in the code.",
+          "scope": "window",
+          "examples": [
+            true,
+            false
+          ]
+        },
+        "deno.codeLens.referencesAllFunctions": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enables or disables the display of code lens information for all functions in the code.",
+          "scope": "window",
+          "examples": [
+            true,
+            false
+          ]
+        },
         "deno.config": {
           "type": "string",
           "default": null,

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -55,7 +55,7 @@ class Plugin implements ts.server.PluginModule {
       // );
       return scriptFiles;
     });
-    
+
     const findRenameLocations = (
       fileName: string,
       position: number,


### PR DESCRIPTION
This PR adds support to allow the Deno LSP to display "reference" code lenses.

Code Lenses are disabled by default for Deno, and for references there are two options to enable them:

- `deno.codeLens.references` - Display code lenses information which allows you to see visually how many references an item has in the code.
- `deno.codeLens.referencesAllFunctions` - Display reference information for all functions (this can get a bit annoying, so this sub option aligns to the vscode built in plugin for TypeScript).

An example of it working in VSCode:

![Jan-29-2021 15-30-11](https://user-images.githubusercontent.com/1282577/106235149-3e78b000-624e-11eb-8418-0dc9e5f4e775.gif)

This requires a version of Deno that includes denoland/deno#9316 for it do anything useful.