### PR TITLE
fix: remove deno/applyCodeActionCommand

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -12,10 +12,7 @@ import {
   workspace,
 } from "vscode";
 import { LanguageClient, Location, Position } from "vscode-languageclient";
-import {
-  applyCodeAction as applyCodeActionReq,
-  cache as cacheReq,
-} from "./lsp_extensions";
+import { cache as cacheReq } from "./lsp_extensions";
 
 // deno-lint-ignore no-explicit-any
 export type Callback = (...args: any[]) => unknown;
@@ -23,15 +20,6 @@ export type Factory = (
   context: ExtensionContext,
   client: LanguageClient,
 ) => Callback;
-
-export function applyCodeAction(
-  _context: ExtensionContext,
-  client: LanguageClient,
-): Callback {
-  // deno-lint-ignore ban-types
-  return (arg: { commands: {}[] }) =>
-    client.sendRequest(applyCodeActionReq, arg);
-}
 
 /** For the current document active in the editor tell the Deno LSP to cache
  * the file and all of its dependencies in the local cache. */

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -139,7 +139,6 @@ export async function activate(
 
   // Register any commands.
   const registerCommand = createRegisterCommand(context);
-  registerCommand("applyCodeAction", commands.applyCodeAction);
   registerCommand("cache", commands.cache);
   registerCommand("showReferences", commands.showReferences);
   registerCommand("status", commands.status);

--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -10,17 +10,6 @@
 import { RequestType } from "vscode-languageclient";
 import type { TextDocumentIdentifier } from "vscode-languageclient";
 
-export interface ApplyCodeActionCommandsParams {
-  // deno-lint-ignore ban-types
-  commands: {}[];
-}
-
-export const applyCodeAction = new RequestType<
-  ApplyCodeActionCommandsParams,
-  void,
-  void
->("deno/applyCodeAction");
-
 export interface CacheParams {
   textDocument: TextDocumentIdentifier;
 }


### PR DESCRIPTION
Looks like I was a bit premature.  We don't need `deno/applyCodeActionCommand` because we won't be processing any of the the fixes that include the command.  The only command at the moment is to do an npm package install.  It also works asynchronously inside of tsc, which our current integration doesn't support, and so it was easier to remove the functionality from the Deno lsp that make it work and then do nothing.