### PR TITLE
feat: use preview instead of display for status

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -8,6 +8,8 @@ import { pickInitWorkspace } from "./initialize_project";
 import { cache as cacheReq } from "./lsp_extensions";
 import { WelcomePanel } from "./welcome";
 
+import * as vscode from "vscode";
+
 import {
   commands,
   ExtensionContext,
@@ -99,11 +101,9 @@ export function status(
   _context: ExtensionContext,
   _client: LanguageClient,
 ): Callback {
-  return async () => {
-    const document = await workspace.openTextDocument(
-      Uri.parse("deno:/status.md"),
-    );
-    return window.showTextDocument(document, ViewColumn.Two, true);
+  return () => {
+    const uri = Uri.parse("deno:/status.md");
+    return vscode.commands.executeCommand("markdown.showPreviewToSide", uri);
   };
 }
 


### PR DESCRIPTION
Instead of previewing the Deno LSP status virtual document as a markdown file, it opens it in markdown preview.  This will allow us to provide a more "readable" version of the status page in the future without having to look directly at markdown.

![_Extension_Development_Host__-_Preview_status_md_—_vs_test](https://user-images.githubusercontent.com/1282577/108429501-2f58b100-7294-11eb-82ba-ca27df3d9ca8.png)
