### PR TITLE
chore: activate extension on command

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -156,6 +156,7 @@ export async function activate(
   context.subscriptions.push(client.start());
   tsApi = await getTsApi();
   await client.onReady();
+  vscode.commands.executeCommand("setContext", "deno:lspReady", true);
   const serverVersion =
     (client.initializeResult?.serverInfo?.version ?? "").split(" ")[0];
   statusBarItem.text = `Deno ${serverVersion}`;
@@ -173,7 +174,9 @@ export function deactivate(): Thenable<void> | undefined {
   if (!client) {
     return undefined;
   }
-  return client.stop();
+  return client.stop().then(() => {
+    vscode.commands.executeCommand("setContext", "deno:lspReady", false);
+  });
 }
 
 function showWelcomePage(context: vscode.ExtensionContext) {

--- a/package.json
+++ b/package.json
@@ -35,18 +35,18 @@
     "onLanguage:typescriptreact",
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
-    "onCommand:deno.cache",
-    "onCommand:deno.status",
+    "onCommand:deno.welcome",
+    "onCommand:deno.initializeWorkspace",
     "onWebviewPanel:welcomeDeno"
   ],
   "main": "./client/out/extension",
   "contributes": {
     "commands": [
       {
-        "command": "deno.cache",
-        "title": "Cache Dependencies",
+        "command": "deno.welcome",
+        "title": "Welcome",
         "category": "Deno",
-        "description": "Cache the active workspace document and its dependencies."
+        "description": "Open the welcome page for the Deno extension."
       },
       {
         "command": "deno.initializeWorkspace",
@@ -55,16 +55,18 @@
         "description": "Initialize the workspace configuration for Deno."
       },
       {
+        "command": "deno.cache",
+        "title": "Cache Dependencies",
+        "category": "Deno",
+        "description": "Cache the active workspace document and its dependencies.",
+        "enablement": "deno:lspReady"
+      },
+      {
         "command": "deno.status",
         "title": "Language Server Status",
         "category": "Deno",
-        "description": "Provide a status document of the language server."
-      },
-      {
-        "command": "deno.welcome",
-        "title": "Welcome",
-        "category": "Deno",
-        "description": "Open the welcome page for the Deno extension."
+        "description": "Provide a status document of the language server.",
+        "enablement": "deno:lspReady"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
   "contributes": {
     "commands": [
       {
-        "command": "deno.welcome",
-        "title": "Welcome",
+        "command": "deno.cache",
+        "title": "Cache Dependencies",
         "category": "Deno",
-        "description": "Open the welcome page for the Deno extension."
+        "description": "Cache the active workspace document and its dependencies.",
+        "enablement": "deno:lspReady"
       },
       {
         "command": "deno.initializeWorkspace",
@@ -55,18 +56,17 @@
         "description": "Initialize the workspace configuration for Deno."
       },
       {
-        "command": "deno.cache",
-        "title": "Cache Dependencies",
-        "category": "Deno",
-        "description": "Cache the active workspace document and its dependencies.",
-        "enablement": "deno:lspReady"
-      },
-      {
         "command": "deno.status",
         "title": "Language Server Status",
         "category": "Deno",
         "description": "Provide a status document of the language server.",
         "enablement": "deno:lspReady"
+      },
+      {
+        "command": "deno.welcome",
+        "title": "Welcome",
+        "category": "Deno",
+        "description": "Open the welcome page for the Deno extension."
       }
     ],
     "configuration": {


### PR DESCRIPTION
Fixes #334

This PR fixes the extension so it activates on the `deno.welcome` and `deno.initializeWorkspace` commands. It also hides the `deno.cache` and `deno.status` commands until the LSP has been started.
