### PR TITLE
feat: add deno.path setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This extension adds support for using [Deno](https://deno.land/) with Visual
 Studio Code, powered by the Deno language server.
 
 > ⚠️ **Important:** You need to have a version of Deno CLI installed (v1.7 or
-> later) and available in your path before attempting to use this extension.
+> later). The extension requires the executable and by default will use the
+> environment path. You can explicitly set the path to the executable in Visual
+> Studio Code Settings for `deno.path`.
 > [Check here](https://deno.land/#installation) for instructions on how to
 > install the Deno CLI.
 
@@ -35,9 +37,11 @@ Studio Code, powered by the Deno language server.
 
 ## Usage
 
-1. Install the Deno CLI, available in your path.
+1. Install the Deno CLI.
 2. Install this extension.
-3. Open the VS Code command palette with `Ctrl+Shift+P`, and run the _Deno:
+3. Ensure `deno` is available in the environment path, or set its path via the
+   `deno.path` setting in VSCode.
+4. Open the VS Code command palette with `Ctrl+Shift+P`, and run the _Deno:
    Initialize Workspace Configuration_ command.
 
 We recognize that not every TypeScript/JavaScript project that you might work on
@@ -88,6 +92,10 @@ extension has the following configuration options:
   the extension will disable the built-in VSCode JavaScript and TypeScript
   language services, and will use the Deno Language Server (`deno lsp`) instead.
   _boolean, default `false`_
+- `deno.path`: A path to the `deno` executable. If unset, the extension will use
+  the environment path to resolve the `deno` executable. If set, the extension
+  will use the supplied path. The path should include the executable name (e.g.
+  `/usr/bin/deno`, `C:\Program Files\deno\deno.exe`).
 - `deno.codeLens.implementations`: Enables or disables the display of code lens
   information for implementations for items in the code. _boolean, default
   `false`_

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -76,15 +76,17 @@ let statusBarItem: vscode.StatusBarItem;
 export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<void> {
+  const command =
+    vscode.workspace.getConfiguration("deno").get<string>("path") || "deno";
   const run: Executable = {
-    command: "deno",
+    command,
     args: ["lsp"],
     // deno-lint-ignore no-undef
     options: { env: { ...process.env, "NO_COLOR": true } },
   };
 
   const debug: Executable = {
-    command: "deno",
+    command,
     // disabled for now, as this gets super chatty during development
     // args: ["lsp", "-L", "debug"],
     args: ["lsp"],

--- a/package.json
+++ b/package.json
@@ -83,6 +83,16 @@
             false
           ]
         },
+        "deno.path": {
+          "type": "string",
+          "default": null,
+          "markdownDescription": "A path to the `deno` CLI executable. By default, the extension looks for `deno` in the `PATH`, but if set, will use the path specified instead.",
+          "scope": "window",
+          "examples": [
+            "/usr/bin/deno",
+            "C:\\Program Files\\deno\\deno.exe"
+          ]
+        },
         "deno.codeLens.implementations": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
This allows setting a specific path to the `deno` executable for the extension, in either the workspace or globally, instead of being dependent on `deno` being in the environment path only.