### PR TITLE
Support for relative path resolution (using workspaces) in deno.path

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -82,20 +82,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const def = await getDefaultDenoCommand();
   let command = vscode.workspace.getConfiguration("deno").get<string>("path");
   if (!command || !workspaces) {
-	command = def;
+    command = def;
   } else if (!path.isAbsolute(command)) {
-	  // if sent a relative path, iterate over workspace folders to try and resolve.
-	  const list = await Promise.all(workspaces.map(async workspace => {
-			const dir = path.resolve(workspace.uri.path, command as string);
-			try {
-				const stat = await fs.promises.stat(dir);
-				if (!stat.isFile()) return false;
-				return dir;
-			} catch (e) {
-				return false;
-			}
-		}))
-		command = list.filter(Boolean).shift() || def;
+    // if sent a relative path, iterate over workspace folders to try and resolve.
+    const list = await Promise.all(workspaces.map(async workspace => {
+      const dir = path.resolve(workspace.uri.path, command as string);
+      try {
+        const stat = await fs.promises.stat(dir);
+        if (!stat.isFile()) return false;
+        return dir;
+      } catch (e) {
+        return false;
+      }
+    }))
+    command = list.filter(Boolean).shift() || def;
   }
 
   const run: Executable = {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -77,12 +77,27 @@ let statusBarItem: vscode.StatusBarItem;
 
 /** When the extension activates, this function is called with the extension
  * context, and the extension bootstraps itself. */
-export async function activate(
-  context: vscode.ExtensionContext,
-): Promise<void> {
-  const command =
-    vscode.workspace.getConfiguration("deno").get<string>("path") ||
-    await getDefaultDenoCommand();
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  const workspaces = vscode.workspace.workspaceFolders;
+  const def = await getDefaultDenoCommand();
+  let command = vscode.workspace.getConfiguration("deno").get<string>("path");
+  if (!command || !workspaces) {
+	command = def;
+  } else if (!path.isAbsolute(command)) {
+	  // if sent a relative path, iterate over workspace folders to try and resolve.
+	  const list = await Promise.all(workspaces.map(async workspace => {
+			const dir = path.resolve(workspace.uri.path, command as string);
+			try {
+				const stat = await fs.promises.stat(dir);
+				if (!stat.isFile()) return false;
+				return dir;
+			} catch (e) {
+				return false;
+			}
+		}))
+		command = list.filter(Boolean).shift() || def;
+  }
+
   const run: Executable = {
     command,
     args: ["lsp"],

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -82,7 +82,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const def = await getDefaultDenoCommand();
   let command = vscode.workspace.getConfiguration("deno").get<string>("path");
   if (!command || !workspaces) {
-    command = def;
+    command = command || def;
   } else if (!path.isAbsolute(command)) {
     // if sent a relative path, iterate over workspace folders to try and resolve.
     const list = await Promise.all(workspaces.map(async workspace => {


### PR DESCRIPTION
We needed this because our project has a monorepo, and the deno binary is automatically installed on a folder relative to the workspace