### PR TITLE
Fix truthy config

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -110,7 +110,6 @@ function configToResourceSettings(
       value.globalValue ||
       value.defaultValue;
   }
-  resourceSettings['config'] = resourceSettings['config'] || false;
   return resourceSettings;
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -80,17 +80,17 @@ function configToWorkspaceSettings(
   for (const key of workspaceSettingsKeys) {
     const value = config.inspect(key);
     assert(value);
-    workspaceSettings[key] = value.workspaceLanguageValue ??
-      value.workspaceValue ??
-      value.globalValue ??
+    workspaceSettings[key] = value.workspaceLanguageValue ||
+      value.workspaceValue ||
+      value.globalValue ||
       value.defaultValue;
   }
   for (const key of resourceSettingsKeys) {
     const value = config.inspect(key);
     assert(value);
-    workspaceSettings[key] = value.workspaceLanguageValue ??
-      value.workspaceValue ??
-      value.globalValue ??
+    workspaceSettings[key] = value.workspaceLanguageValue ||
+      value.workspaceValue ||
+      value.globalValue ||
       value.defaultValue;
   }
   return workspaceSettings;
@@ -104,12 +104,13 @@ function configToResourceSettings(
   for (const key of resourceSettingsKeys) {
     const value = config.inspect(key);
     assert(value);
-    resourceSettings[key] = value.workspaceFolderLanguageValue ??
-      value.workspaceFolderValue ?? value.workspaceLanguageValue ??
-      value.workspaceValue ??
-      value.globalValue ??
+    resourceSettings[key] = value.workspaceFolderLanguageValue ||
+      value.workspaceFolderValue || value.workspaceLanguageValue ||
+      value.workspaceValue ||
+      value.globalValue ||
       value.defaultValue;
   }
+  resourceSettings['config'] = resourceSettings['config'] || false;
   return resourceSettings;
 }
 


### PR DESCRIPTION
This PR is for this issue: https://github.com/denoland/deno/issues/10808

Diagnosis
---
If in Settings, someone puts an empty string into config, the `??` will evaluate that to `true` rather than short-circuit to `value.defaultValue` (which I believe is `null`, and comes from `package.json`).

Replication
---
This is my first time editing a vscode extension, so the way that I verified that the fix works is by going to `${HOME}/.vscode-oss/extensions/denoland.vscode-deno-3.4.0/client/out/extension.js` and making the change. Now, even if config is an empty string (with the orange indicator line showing), it fixes the issue with language server.


I don't know if this would be your preferred solution, or if you'd prefer an exception specifically for the config variable, or if I should instead patch lsp. Let me know and I can update it.