### PR TITLE
feat: support registry auto discovery

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -14,6 +14,8 @@ import type {
 } from "./interfaces";
 import { DenoTextDocumentContentProvider, SCHEME } from "./content_provider";
 import { DenoDebugConfigurationProvider } from "./debug_config_provider";
+import { registryState } from "./lsp_extensions";
+import { createRegistryStateHandler } from "./notification_handlers";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -267,6 +269,13 @@ export async function activate(
   extensionContext.tsApi = await getTsApi();
 
   await commands.startLanguageServer(context, extensionContext)();
+
+  context.subscriptions.push(
+    extensionContext.client.onNotification(
+      registryState,
+      createRegistryStateHandler(),
+    ),
+  );
 
   extensionContext.documentSettings = {};
   extensionContext.workspaceSettings = getWorkspaceSettings();

--- a/client/src/interfaces.d.ts
+++ b/client/src/interfaces.d.ts
@@ -35,6 +35,7 @@ export interface Settings {
     names: boolean;
     paths: boolean;
     imports: {
+      autoDiscover: boolean;
       hosts: Record<string, boolean>;
     } | null;
   } | null;

--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -7,7 +7,11 @@
  * `cli/lsp/language_server.rs` under the method `request_else`.
  */
 
-import { RequestType, RequestType0 } from "vscode-languageclient";
+import {
+  NotificationType,
+  RequestType,
+  RequestType0,
+} from "vscode-languageclient";
 import type { TextDocumentIdentifier } from "vscode-languageclient";
 
 export interface CacheParams {
@@ -19,6 +23,15 @@ export const cache = new RequestType<CacheParams, boolean, void>("deno/cache");
 
 export const reloadImportRegistries = new RequestType0<boolean, void>(
   "deno/reloadImportRegistries",
+);
+
+export interface RegistryStateParams {
+  origin: string;
+  suggestions: boolean;
+}
+
+export const registryState = new NotificationType<RegistryStateParams>(
+  "deno/registryState",
 );
 
 export interface VirtualTextDocumentParams {

--- a/client/src/notification_handlers.ts
+++ b/client/src/notification_handlers.ts
@@ -11,7 +11,7 @@ export function createRegistryStateHandler(): NotificationHandler<
     let enable = false;
     if (suggestions) {
       const selection = await vscode.window.showInformationMessage(
-        `The server "${origin}" supports completion suggestions for imports. Do you wish to enable this?\n\n*Only do this if you trust "${origin}".*\n\n[Learn More](https://github.com/denoland/vscode_deno/blob/main/docs/ImportCompletions.md)`,
+        `The server "${origin}" supports completion suggestions for imports. Do you wish to enable this? (Only do this if you trust "${origin}") [Learn More](https://github.com/denoland/vscode_deno/blob/main/docs/ImportCompletions.md)`,
         "No",
         "Enable",
       );

--- a/client/src/notification_handlers.ts
+++ b/client/src/notification_handlers.ts
@@ -1,0 +1,32 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { RegistryStateParams } from "./lsp_extensions";
+import { NotificationHandler } from "vscode-languageclient";
+import * as vscode from "vscode";
+
+export function createRegistryStateHandler(): NotificationHandler<
+  RegistryStateParams
+> {
+  return async function handler({ origin, suggestions }) {
+    let enable = false;
+    if (suggestions) {
+      const selection = await vscode.window.showInformationMessage(
+        `The server "${origin}" supports completion suggestions for imports. Do you wish to enable this?\n\n*Only do this if you trust "${origin}".*\n\n[Learn More](https://github.com/denoland/vscode_deno/blob/main/docs/ImportCompletions.md)`,
+        "No",
+        "Enable",
+      );
+      enable = selection === "Enable";
+    }
+    const suggestImportsConfig = vscode.workspace.getConfiguration(
+      "deno.suggest.imports",
+    );
+    const hosts: Record<string, boolean> = suggestImportsConfig.get("hosts") ??
+      {};
+    hosts[origin] = enable;
+    await suggestImportsConfig.update(
+      "hosts",
+      hosts,
+      vscode.ConfigurationTarget.Workspace,
+    );
+  };
+}

--- a/docs/ImportCompletions.md
+++ b/docs/ImportCompletions.md
@@ -22,10 +22,25 @@ Module registries that support it can be configured for auto completion. This
 provides a handy way to explore a module registry from the "comfort" of your
 IDE.
 
+### Auto-discovery
+
+The Deno language server, by default, will attempt to determine if a server
+supports completion suggestions. If the host/origin has not been explicitly
+configured, it will check the server, and if it supports completion suggestions
+you will be prompted to choose to enable it or not.
+
+You should only enable this for registries you trust, as the remote server could
+provide suggestions for modules which are an attempt to get you to run
+un-trusted code.
+
 ### Configuration
 
 Settings for configuring registries for auto completions:
 
+- `deno.suggest.imports.autoDiscover` - If enabled, when the language server
+  discovers a new origin that isn't explicitly configured, it will check to see
+  if that origin supports import completions and prompt you to enable it or not.
+  This is `true` by default.
 - `deno.suggest.imports.hosts` - These are the _origins_ that are configured to
   provide import completions. The target host needs to support Deno import
   completions (detailed below). The value is an object where the key is the host

--- a/package.json
+++ b/package.json
@@ -230,6 +230,12 @@
           "default": true,
           "scope": "window"
         },
+        "deno.suggest.imports.autoDiscover": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "If enabled, when new hosts/origins are encountered that support import suggestions, you will be prompted to enable or disable it.  Defaults to `true`.",
+          "scope": "window"
+        },
         "deno.suggest.imports.hosts": {
           "type": "object",
           "default": {},

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -40,6 +40,7 @@ const defaultSettings: Settings = {
     names: true,
     paths: true,
     imports: {
+      autoDiscover: true,
       hosts: {},
     },
   },


### PR DESCRIPTION
Add the `deno.suggest.imports.autoDiscover` option and responds to `deno/registryState` notifications.

Requires denoland/deno#10813 to do anything useful.