### PR TITLE
fix: bump semver of extension

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -24,7 +24,7 @@ import * as vscode from "vscode";
 import type { Executable } from "vscode-languageclient/node";
 
 /** The minimum version of Deno that this extension is designed to support. */
-const SERVER_SEMVER = ">=1.9.0";
+const SERVER_SEMVER = ">=1.10.3";
 
 /** The language IDs we care about. */
 const LANGUAGES = [


### PR DESCRIPTION
Sets the semver to `>=1.10.3` which includes the ability to format `.md`, where in earlier versions will cause strange diagnostics.