### PR TITLE
fix: update packaging and pin vsce version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: npm run compile
 
       - name: Package
-        run: npx vsce package -o vscode-deno.vsix
+        run: npx vsce@1.93.0 package -o vscode-deno.vsix
 
       - name: Artifact upload
         uses: actions/upload-artifact@v2
@@ -77,4 +77,4 @@ jobs:
         env:
           # https://dev.azure.com/propelml/_usersSettings/tokens
           AZURE_PAT: ${{ secrets.AZURE_PAT }}
-        run: npx vsce publish --pat $AZURE_PAT
+        run: npx vsce@1.93.0 publish --pat $AZURE_PAT

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,5 +5,4 @@
 **/tsconfig.json
 **/tsconfig.base.json
 
-screenshot
-typescript-deno-plugin
+/typescript-deno-plugin


### PR DESCRIPTION
Fixes #439

Updates the `.vscodeingore` which changed behaviour in the `vsce` tool for packaging extensions as well as pins at a specific version to avoid accidental breaking changes in the future.