### PR TITLE
fix: use parent-pid flag to prevent orphaned processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 This extension adds support for using [Deno](https://deno.land/) with Visual
 Studio Code, powered by the Deno language server.
 
-> ⚠️ **Important:** You need to have a version of Deno CLI installed (v1.10.3 or
+> ⚠️ **Important:** You need to have a version of Deno CLI installed (v1.11.2 or
 > later). The extension requires the executable and by default will use the
 > environment path. You can explicitly set the path to the executable in Visual
 > Studio Code Settings for `deno.path`.

--- a/client/src/content_provider.ts
+++ b/client/src/content_provider.ts
@@ -20,6 +20,10 @@ export class DenoTextDocumentContentProvider
     uri: Uri,
     token: CancellationToken,
   ): ProviderResult<string> {
+    if (!this.extensionContext.client) {
+      throw new Error("Deno language server has not started.");
+    }
+
     return this.extensionContext.client.sendRequest(
       virtualTextDocument,
       { textDocument: { uri: uri.toString() } },

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,7 +17,7 @@ import type {
   Settings,
   TsLanguageFeaturesApiV0,
 } from "./types";
-import { assert, getDenoCommand } from "./util";
+import { assert, getDenoCommand, getDenoLspArgs } from "./util";
 
 import * as path from "path";
 import * as semver from "semver";
@@ -176,9 +176,10 @@ export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   const command = await getDenoCommand();
+  const args = await getDenoLspArgs();
   const run: Executable = {
     command,
-    args: ["lsp"],
+    args,
     // deno-lint-ignore no-undef
     options: { env: { ...process.env, "NO_COLOR": true } },
   };
@@ -186,8 +187,8 @@ export async function activate(
   const debug: Executable = {
     command,
     // disabled for now, as this gets super chatty during development
-    // args: ["lsp", "-L", "debug"],
-    args: ["lsp"],
+    // args: [...args, "-L", "debug"],
+    args,
     // deno-lint-ignore no-undef
     options: { env: { ...process.env, "NO_COLOR": true } },
   };

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,7 +17,7 @@ import type {
   Settings,
   TsLanguageFeaturesApiV0,
 } from "./types";
-import { assert, getDenoCommand, getDenoLspArgs } from "./util";
+import { assert, getDenoCommand } from "./util";
 
 import * as path from "path";
 import * as semver from "semver";
@@ -25,7 +25,7 @@ import * as vscode from "vscode";
 import type { Executable } from "vscode-languageclient/node";
 
 /** The minimum version of Deno that this extension is designed to support. */
-const SERVER_SEMVER = ">=1.10.3";
+const SERVER_SEMVER = ">=1.11.2";
 
 /** The language IDs we care about. */
 const LANGUAGES = [
@@ -176,7 +176,7 @@ export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   const command = await getDenoCommand();
-  const args = await getDenoLspArgs();
+  const args = ["lsp", "--parent-pid", process.pid.toString()];
   const run: Executable = {
     command,
     args,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -249,12 +249,12 @@ export async function activate(
   extensionContext.workspaceSettings = getWorkspaceSettings();
   configurePlugin();
 
-  await commands.startLanguageServer(context, extensionContext)();
-
   // when we activate, it might have been because a document was opened that
   // activated us, which we need to grab the config for and send it over to the
   // plugin
   handleDocumentOpen(...vscode.workspace.textDocuments);
+
+  await commands.startLanguageServer(context, extensionContext)();
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -4,7 +4,6 @@ import type { ConfigurationScope, StatusBarItem } from "vscode";
 import type {
   LanguageClient,
   LanguageClientOptions,
-  ServerOptions,
 } from "vscode-languageclient/node";
 
 /** When `vscode.WorkspaceSettings` get serialized, they keys of the
@@ -57,11 +56,10 @@ export interface DocumentSettings {
 }
 
 export interface DenoExtensionContext {
-  client: LanguageClient;
+  client: LanguageClient | undefined;
   clientOptions: LanguageClientOptions;
   /** A record of filepaths and their document settings. */
   documentSettings: Record<string, DocumentSettings>;
-  serverOptions: ServerOptions;
   serverVersion: string;
   statusBarItem: StatusBarItem;
   tsApi: TsLanguageFeaturesApiV0;

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -135,6 +135,9 @@ function getDefaultDenoCommand() {
 
 function execCommand(command: string): Promise<string> {
   return new Promise((resolve, reject) => {
+    // todo(dsherret): this should handle multiple workspace folders
+    // in order to better support directory based deno executable
+    // version managers. For now, this is good enough.
     const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     childProcess.exec(command, {
       cwd,

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,11 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import * as process from "process";
-import * as semver from "semver";
 import * as vscode from "vscode";
 
 /** Assert that the condition is "truthy", otherwise throw. */
@@ -13,36 +10,6 @@ export function assert(cond: unknown, msg = "Assertion failed."): asserts cond {
   if (!cond) {
     throw new Error(msg);
   }
-}
-
-export async function getDenoLspArgs(): Promise<string[]> {
-  const version = await getDenoVersion();
-  // The --parent-pid <pid> flag was added in 1.11.2.
-  if (version == null || semver.lt(version, "1.11.2")) {
-    return ["lsp"];
-  } else {
-    // The --parent-pid flag will cause the deno process to
-    // terminate itself when the vscode process no longer exists
-    return ["lsp", "--parent-pid", process.pid.toString()];
-  }
-}
-
-let memoizedVersion: semver.SemVer | undefined;
-
-export async function getDenoVersion(): Promise<semver.SemVer | undefined> {
-  if (memoizedVersion === undefined) {
-    try {
-      const denoCommand = await getDenoCommand();
-      const output = await execCommand(`${denoCommand} -V`);
-      const result = /[0-9]+\.[0-9]+\.[0-9]+/.exec(output);
-      if (result != null) {
-        memoizedVersion = new semver.SemVer(result[0]);
-      }
-    } catch (err) {
-      console.error(`Error getting deno version: ${err}`);
-    }
-  }
-  return memoizedVersion;
 }
 
 let memoizedCommand: string | undefined;
@@ -129,16 +96,4 @@ function getDefaultDenoCommand() {
       return false;
     });
   }
-}
-
-function execCommand(command: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    childProcess.exec(command, (err, stdout, stderr) => {
-      if (err) {
-        reject(stderr);
-      } else {
-        resolve(stdout);
-      }
-    });
-  });
 }

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,8 +1,11 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as process from "process";
+import * as semver from "semver";
 import * as vscode from "vscode";
 
 /** Assert that the condition is "truthy", otherwise throw. */
@@ -10,6 +13,36 @@ export function assert(cond: unknown, msg = "Assertion failed."): asserts cond {
   if (!cond) {
     throw new Error(msg);
   }
+}
+
+export async function getDenoLspArgs(): Promise<string[]> {
+  const version = await getDenoVersion();
+  // The --parent-pid <pid> flag was added in 1.11.2.
+  if (version == null || semver.lt(version, "1.11.2")) {
+    return ["lsp"];
+  } else {
+    // The --parent-pid flag will cause the deno process to
+    // terminate itself when the vscode process no longer exists
+    return ["lsp", "--parent-pid", process.pid.toString()];
+  }
+}
+
+let memoizedVersion: semver.SemVer | undefined;
+
+export async function getDenoVersion(): Promise<semver.SemVer | undefined> {
+  if (memoizedVersion === undefined) {
+    try {
+      const denoCommand = await getDenoCommand();
+      const output = await execCommand(`${denoCommand} -V`);
+      const result = /[0-9]+\.[0-9]+\.[0-9]+/.exec(output);
+      if (result != null) {
+        memoizedVersion = new semver.SemVer(result[0]);
+      }
+    } catch (err) {
+      console.error(`Error getting deno version: ${err}`);
+    }
+  }
+  return memoizedVersion;
 }
 
 let memoizedCommand: string | undefined;
@@ -96,4 +129,16 @@ function getDefaultDenoCommand() {
       return false;
     });
   }
+}
+
+function execCommand(command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    childProcess.exec(command, (err, stdout, stderr) => {
+      if (err) {
+        reject(stderr);
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-deno",
   "displayName": "Deno",
-  "description": "A language server client for Deno. Requires Deno 1.8 or better.",
+  "description": "A language server client for Deno.",
   "author": "Deno Land Inc.",
   "license": "MIT",
   "version": "3.6.1",


### PR DESCRIPTION
We need to run `deno -V` to figure out the version because we can't call `deno lsp --parent-pid <pid>` on an old version of Deno.

Had to do a bit of a refactor to implement this.

Relates to #374