### PR TITLE
fix: better handling when language server fails to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 This extension adds support for using [Deno](https://deno.land/) with Visual
 Studio Code, powered by the Deno language server.
 
-> ⚠️ **Important:** You need to have a version of Deno CLI installed (v1.11.2 or
+> ⚠️ **Important:** You need to have a version of Deno CLI installed (v1.10.3 or
 > later). The extension requires the executable and by default will use the
 > environment path. You can explicitly set the path to the executable in Visual
 > Studio Code Settings for `deno.path`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 This extension adds support for using [Deno](https://deno.land/) with Visual
 Studio Code, powered by the Deno language server.
 
-> ⚠️ **Important:** You need to have a version of Deno CLI installed (v1.10.3 or
+> ⚠️ **Important:** You need to have a version of Deno CLI installed (v1.11.2 or
 > later). The extension requires the executable and by default will use the
 > environment path. You can explicitly set the path to the executable in Visual
 > Studio Code Settings for `deno.path`.

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -20,6 +20,7 @@ import { WelcomePanel } from "./welcome";
 import { assert, getDenoCommand } from "./util";
 import { registryState } from "./lsp_extensions";
 import { createRegistryStateHandler } from "./notification_handlers";
+import { configurePlugin } from "./ts_api";
 
 import * as semver from "semver";
 import * as vscode from "vscode";
@@ -29,7 +30,6 @@ import type {
   Location,
   Position,
 } from "vscode-languageclient/node";
-import { configurePlugin } from "./ts_api";
 
 /** The minimum version of Deno that this extension is designed to support. */
 const SERVER_SEMVER = ">=1.10.3";
@@ -106,10 +106,11 @@ export function startLanguageServer(
     // Stop the existing language server and reset the state
     const { statusBarItem } = extensionContext;
     if (extensionContext.client) {
-      await extensionContext.client.stop();
+      const client = extensionContext.client;
       extensionContext.client = undefined;
       statusBarItem.hide();
       vscode.commands.executeCommand("setContext", ENABLEMENT_FLAG, false);
+      await client.stop();
     }
 
     // Start a new language server

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -8,6 +8,7 @@ import {
   EXTENSION_NS,
   LANGUAGE_CLIENT_ID,
   LANGUAGE_CLIENT_NAME,
+  SERVER_SEMVER,
 } from "./constants";
 import { pickInitWorkspace } from "./initialize_project";
 import {
@@ -29,9 +30,6 @@ import type {
   Location,
   Position,
 } from "vscode-languageclient/node";
-
-/** The minimum version of Deno that this extension is designed to support. */
-const SERVER_SEMVER = ">=1.10.3";
 
 // deno-lint-ignore no-explicit-any
 export type Callback = (...args: any[]) => unknown;
@@ -91,9 +89,9 @@ export function initializeWorkspace(
 
 export function reloadImportRegistries(
   _context: vscode.ExtensionContext,
-  { client }: DenoExtensionContext,
+  extensionContext: DenoExtensionContext,
 ): Callback {
-  return () => client?.sendRequest(reloadImportRegistriesReq);
+  return () => extensionContext.client?.sendRequest(reloadImportRegistriesReq);
 }
 
 /** Start (or restart) the Deno Language Server */

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -20,7 +20,6 @@ import { WelcomePanel } from "./welcome";
 import { assert, getDenoCommand } from "./util";
 import { registryState } from "./lsp_extensions";
 import { createRegistryStateHandler } from "./notification_handlers";
-import { configurePlugin } from "./ts_api";
 
 import * as semver from "semver";
 import * as vscode from "vscode";
@@ -161,7 +160,7 @@ export function startLanguageServer(
       ),
     );
 
-    configurePlugin(extensionContext);
+    extensionContext.tsApi.refresh();
 
     if (
       semver.valid(extensionContext.serverVersion) &&

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -8,3 +8,5 @@ export const LANGUAGE_CLIENT_ID = "deno-language-server";
 export const LANGUAGE_CLIENT_NAME = "Deno Language Server";
 export const TS_LANGUAGE_FEATURES_EXTENSION =
   "vscode.typescript-language-features";
+/** The minimum version of Deno that this extension is designed to support. */
+export const SERVER_SEMVER = ">=1.10.3";

--- a/client/src/content_provider.ts
+++ b/client/src/content_provider.ts
@@ -20,6 +20,10 @@ export class DenoTextDocumentContentProvider
     uri: Uri,
     token: CancellationToken,
   ): ProviderResult<string> {
+    if (!this.extensionContext.client) {
+      throw new Error("Deno language server has not started.");
+    }
+
     return this.extensionContext.client.sendRequest(
       virtualTextDocument,
       { textDocument: { uri: uri.toString() } },

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -108,9 +108,10 @@ function handleConfigurationChange(event: vscode.ConfigurationChangeEvent) {
     }
     configurePlugin(extensionContext);
 
-    // Restart the language server. This will allow for
-    // "deno.path" configuration changes to take effect.
-    vscode.commands.executeCommand("deno.restart");
+    // restart when "deno.path" changes
+    if (event.affectsConfiguration("deno.path")) {
+      vscode.commands.executeCommand("deno.restart");
+    }
   }
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,7 +17,7 @@ import type {
   Settings,
   TsLanguageFeaturesApiV0,
 } from "./types";
-import { assert, getDenoCommand } from "./util";
+import { assert, getDenoCommand, getDenoLspArgs } from "./util";
 
 import * as path from "path";
 import * as semver from "semver";
@@ -176,9 +176,10 @@ export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   const command = await getDenoCommand();
+  const args = await getDenoLspArgs();
   const run: Executable = {
     command,
-    args: ["lsp"],
+    args,
     // deno-lint-ignore no-undef
     options: { env: { ...process.env, "NO_COLOR": true } },
   };
@@ -186,8 +187,8 @@ export async function activate(
   const debug: Executable = {
     command,
     // disabled for now, as this gets super chatty during development
-    // args: ["lsp", "-L", "debug"],
-    args: ["lsp"],
+    // args: [...args, "-L", "debug"],
+    args,
     // deno-lint-ignore no-undef
     options: { env: { ...process.env, "NO_COLOR": true } },
   };

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -10,7 +10,7 @@ import { assert } from "./util";
 
 import * as path from "path";
 import * as vscode from "vscode";
-import { configurePlugin, getTsApi } from "./ts_api";
+import { getTsApi } from "./ts_api";
 
 /** The language IDs we care about. */
 const LANGUAGES = [
@@ -106,7 +106,7 @@ function handleConfigurationChange(event: vscode.ConfigurationChangeEvent) {
         ),
       };
     }
-    configurePlugin(extensionContext);
+    extensionContext.tsApi.refresh();
 
     // restart when "deno.path" changes
     if (event.affectsConfiguration("deno.path")) {
@@ -131,7 +131,7 @@ function handleDocumentOpen(...documents: vscode.TextDocument[]) {
     didChange = true;
   }
   if (didChange) {
-    configurePlugin(extensionContext);
+    extensionContext.tsApi.refresh();
   }
 }
 
@@ -214,7 +214,11 @@ export async function activate(
   registerCommand("test", commands.test);
   registerCommand("welcome", commands.welcome);
 
-  extensionContext.tsApi = await getTsApi();
+  extensionContext.tsApi = await getTsApi(() => ({
+    documents: extensionContext.documentSettings,
+    workspace: extensionContext.workspaceSettings,
+  }));
+
   extensionContext.documentSettings = {};
   extensionContext.workspaceSettings = getWorkspaceSettings();
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,7 +17,7 @@ import type {
   Settings,
   TsLanguageFeaturesApiV0,
 } from "./types";
-import { assert, getDenoCommand, getDenoLspArgs } from "./util";
+import { assert, getDenoCommand } from "./util";
 
 import * as path from "path";
 import * as semver from "semver";
@@ -25,7 +25,7 @@ import * as vscode from "vscode";
 import type { Executable } from "vscode-languageclient/node";
 
 /** The minimum version of Deno that this extension is designed to support. */
-const SERVER_SEMVER = ">=1.10.3";
+const SERVER_SEMVER = ">=1.11.2";
 
 /** The language IDs we care about. */
 const LANGUAGES = [
@@ -176,7 +176,7 @@ export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<void> {
   const command = await getDenoCommand();
-  const args = await getDenoLspArgs();
+  const args = ["lsp", "--parent-pid", process.pid.toString()];
   const run: Executable = {
     command,
     args,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -249,12 +249,12 @@ export async function activate(
   extensionContext.workspaceSettings = getWorkspaceSettings();
   configurePlugin();
 
-  await commands.startLanguageServer(context, extensionContext)();
-
   // when we activate, it might have been because a document was opened that
   // activated us, which we need to grab the config for and send it over to the
   // plugin
   handleDocumentOpen(...vscode.workspace.textDocuments);
+
+  await commands.startLanguageServer(context, extensionContext)();
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/client/src/ts_api.ts
+++ b/client/src/ts_api.ts
@@ -1,0 +1,33 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import {
+  EXTENSION_TS_PLUGIN,
+  TS_LANGUAGE_FEATURES_EXTENSION,
+} from "./constants";
+import type { DenoExtensionContext, TsLanguageFeaturesApiV0 } from "./types";
+import { assert } from "./util";
+
+import * as vscode from "vscode";
+
+interface TsLanguageFeatures {
+  getAPI(version: 0): TsLanguageFeaturesApiV0 | undefined;
+}
+
+export async function getTsApi(): Promise<TsLanguageFeaturesApiV0> {
+  const extension: vscode.Extension<TsLanguageFeatures> | undefined = vscode
+    .extensions.getExtension(TS_LANGUAGE_FEATURES_EXTENSION);
+  const errorMessage =
+    "The Deno extension cannot load the built in TypeScript Language Features. Please try restarting Visual Studio Code.";
+  assert(extension, errorMessage);
+  const languageFeatures = await extension.activate();
+  const api = languageFeatures.getAPI(0);
+  assert(api, errorMessage);
+  return api;
+}
+
+/** Update the typescript-deno-plugin with settings. */
+export function configurePlugin(extensionContext: DenoExtensionContext) {
+  const { documentSettings: documents, tsApi, workspaceSettings: workspace } =
+    extensionContext;
+  tsApi.configurePlugin(EXTENSION_TS_PLUGIN, { workspace, documents });
+}

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -4,7 +4,6 @@ import type { ConfigurationScope, StatusBarItem } from "vscode";
 import type {
   LanguageClient,
   LanguageClientOptions,
-  ServerOptions,
 } from "vscode-languageclient/node";
 
 /** When `vscode.WorkspaceSettings` get serialized, they keys of the
@@ -57,11 +56,10 @@ export interface DocumentSettings {
 }
 
 export interface DenoExtensionContext {
-  client: LanguageClient;
+  client: LanguageClient | undefined;
   clientOptions: LanguageClientOptions;
   /** A record of filepaths and their document settings. */
   documentSettings: Record<string, DocumentSettings>;
-  serverOptions: ServerOptions;
   serverVersion: string;
   statusBarItem: StatusBarItem;
   tsApi: TsLanguageFeaturesApiV0;

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -55,6 +55,11 @@ export interface DocumentSettings {
   settings: Partial<Settings>;
 }
 
+export interface TsApi {
+  /** Update the typescript-deno-plugin with settings. */
+  refresh(): void;
+}
+
 export interface DenoExtensionContext {
   client: LanguageClient | undefined;
   clientOptions: LanguageClientOptions;
@@ -62,14 +67,7 @@ export interface DenoExtensionContext {
   documentSettings: Record<string, DocumentSettings>;
   serverVersion: string;
   statusBarItem: StatusBarItem;
-  tsApi: TsLanguageFeaturesApiV0;
+  tsApi: TsApi;
   /** The current workspace settings. */
   workspaceSettings: Settings;
-}
-
-export interface TsLanguageFeaturesApiV0 {
-  configurePlugin(
-    pluginId: string,
-    configuration: PluginSettings,
-  ): void;
 }

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -135,6 +135,9 @@ function getDefaultDenoCommand() {
 
 function execCommand(command: string): Promise<string> {
   return new Promise((resolve, reject) => {
+    // todo(dsherret): this should handle multiple workspace folders
+    // in order to better support directory based deno executable
+    // version managers. For now, this is good enough.
     const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     childProcess.exec(command, {
       cwd,

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,11 +1,8 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import * as process from "process";
-import * as semver from "semver";
 import * as vscode from "vscode";
 
 /** Assert that the condition is "truthy", otherwise throw. */
@@ -13,36 +10,6 @@ export function assert(cond: unknown, msg = "Assertion failed."): asserts cond {
   if (!cond) {
     throw new Error(msg);
   }
-}
-
-export async function getDenoLspArgs(): Promise<string[]> {
-  const version = await getDenoVersion();
-  // The --parent-pid <pid> flag was added in 1.11.2.
-  if (version == null || semver.lt(version, "1.11.2")) {
-    return ["lsp"];
-  } else {
-    // The --parent-pid flag will cause the deno process to
-    // terminate itself when the vscode process no longer exists
-    return ["lsp", "--parent-pid", process.pid.toString()];
-  }
-}
-
-let memoizedVersion: semver.SemVer | undefined;
-
-export async function getDenoVersion(): Promise<semver.SemVer | undefined> {
-  if (memoizedVersion === undefined) {
-    try {
-      const denoCommand = await getDenoCommand();
-      const output = await execCommand(`${denoCommand} -V`);
-      const result = /[0-9]+\.[0-9]+\.[0-9]+/.exec(output);
-      if (result != null) {
-        memoizedVersion = new semver.SemVer(result[0]);
-      }
-    } catch (err) {
-      console.error(`Error getting deno version: ${err}`);
-    }
-  }
-  return memoizedVersion;
 }
 
 let memoizedCommand: string | undefined;
@@ -129,16 +96,4 @@ function getDefaultDenoCommand() {
       return false;
     });
   }
-}
-
-function execCommand(command: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    childProcess.exec(command, (err, stdout, stderr) => {
-      if (err) {
-        reject(stderr);
-      } else {
-        resolve(stdout);
-      }
-    });
-  });
 }

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -41,9 +41,8 @@ export async function getDenoCommand(): Promise<string> {
 }
 
 function getWorkspaceConfigDenoExePath() {
-  const exePath = vscode.workspace.getConfiguration(EXTENSION_NS).get<string>(
-    "path",
-  );
+  const exePath = vscode.workspace.getConfiguration(EXTENSION_NS)
+    .get<string>("path");
   // it is possible for the path to be blank. In that case, return undefined
   if (typeof exePath === "string" && exePath.trim().length === 0) {
     return undefined;

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,11 +1,9 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as process from "process";
-import * as semver from "semver";
 import * as vscode from "vscode";
 
 /** Assert that the condition is "truthy", otherwise throw. */
@@ -13,33 +11,6 @@ export function assert(cond: unknown, msg = "Assertion failed."): asserts cond {
   if (!cond) {
     throw new Error(msg);
   }
-}
-
-export interface DenoCommandAndVersion {
-  command: string;
-  /** The version of the deno CLI or undefined if it couldn't be determined. */
-  version: semver.SemVer | undefined;
-}
-
-export async function getDenoCommandAndVersion(): Promise<
-  DenoCommandAndVersion
-> {
-  let version: semver.SemVer | undefined;
-  let command = "deno";
-  try {
-    command = await getDenoCommand();
-    const output = await execCommand(`${command} -V`);
-    const result = /[0-9]+\.[0-9]+\.[0-9]+/.exec(output);
-    if (result != null) {
-      version = new semver.SemVer(result[0]);
-    }
-  } catch (err) {
-    console.error(`Error getting deno version: ${err}`);
-  }
-  return {
-    command,
-    version,
-  };
 }
 
 export async function getDenoCommand(): Promise<string> {
@@ -131,22 +102,4 @@ function getDefaultDenoCommand() {
       return false;
     });
   }
-}
-
-function execCommand(command: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    // todo(dsherret): this should handle multiple workspace folders
-    // in order to better support directory based deno executable
-    // version managers. For now, this is good enough.
-    const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    childProcess.exec(command, {
-      cwd,
-    }, (err, stdout, stderr) => {
-      if (err) {
-        reject(stderr);
-      } else {
-        resolve(stdout);
-      }
-    });
-  });
 }

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+import { EXTENSION_NS } from "./constants";
+
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -39,7 +41,9 @@ export async function getDenoCommand(): Promise<string> {
 }
 
 function getWorkspaceConfigDenoExePath() {
-  const exePath = vscode.workspace.getConfiguration("deno").get<string>("path");
+  const exePath = vscode.workspace.getConfiguration(EXTENSION_NS).get<string>(
+    "path",
+  );
   // it is possible for the path to be blank. In that case, return undefined
   if (typeof exePath === "string" && exePath.trim().length === 0) {
     return undefined;

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,8 +1,11 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as process from "process";
+import * as semver from "semver";
 import * as vscode from "vscode";
 
 /** Assert that the condition is "truthy", otherwise throw. */
@@ -10,6 +13,36 @@ export function assert(cond: unknown, msg = "Assertion failed."): asserts cond {
   if (!cond) {
     throw new Error(msg);
   }
+}
+
+export async function getDenoLspArgs(): Promise<string[]> {
+  const version = await getDenoVersion();
+  // The --parent-pid <pid> flag was added in 1.11.2.
+  if (version == null || semver.lt(version, "1.11.2")) {
+    return ["lsp"];
+  } else {
+    // The --parent-pid flag will cause the deno process to
+    // terminate itself when the vscode process no longer exists
+    return ["lsp", "--parent-pid", process.pid.toString()];
+  }
+}
+
+let memoizedVersion: semver.SemVer | undefined;
+
+export async function getDenoVersion(): Promise<semver.SemVer | undefined> {
+  if (memoizedVersion === undefined) {
+    try {
+      const denoCommand = await getDenoCommand();
+      const output = await execCommand(`${denoCommand} -V`);
+      const result = /[0-9]+\.[0-9]+\.[0-9]+/.exec(output);
+      if (result != null) {
+        memoizedVersion = new semver.SemVer(result[0]);
+      }
+    } catch (err) {
+      console.error(`Error getting deno version: ${err}`);
+    }
+  }
+  return memoizedVersion;
 }
 
 let memoizedCommand: string | undefined;
@@ -96,4 +129,16 @@ function getDefaultDenoCommand() {
       return false;
     });
   }
+}
+
+function execCommand(command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    childProcess.exec(command, (err, stdout, stderr) => {
+      if (err) {
+        reject(stderr);
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
 }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
         "command": "deno.reloadImportRegistries",
         "title": "Reload Import Registries Cache",
         "category": "Deno",
-        "description": "Reload any cached import registry responses."
+        "description": "Reload any cached import registry responses.",
+        "enablement": "deno:lspReady"
       },
       {
         "command": "deno.restart",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-deno",
   "displayName": "Deno",
-  "description": "A language server client for Deno. Requires Deno 1.8 or better.",
+  "description": "A language server client for Deno.",
   "author": "Deno Land Inc.",
   "license": "MIT",
   "version": "3.6.1",


### PR DESCRIPTION
This is essentially #453, but without the `parent-pid` changes.

These changes also...

1. Allow users to update deno then just do the "Restart Language Service" command.
2. Allow users to update "deno.path" and have the changes take effect immediately.