### PR TITLE
feat: add ability to set cache directory in settings

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -234,9 +234,12 @@ export function test(
     if (config.get("unstable")) {
       testArgs.push("--unstable");
     }
-    if (config.get("importMap")) {
+    if (config.has("importMap")) {
       testArgs.push("--import-map", String(config.get("importMap")));
     }
+    const env = config.has("cache")
+      ? { "DENO_DIR": config.get("cache") } as Record<string, string>
+      : undefined;
     const args = ["test", ...testArgs, "--filter", name, path];
 
     const definition: tasks.DenoTaskDefinition = {
@@ -244,6 +247,7 @@ export function test(
       command: "test",
       args,
       cwd: ".",
+      env,
     };
 
     assert(vscode.workspace.workspaceFolders);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -22,6 +22,7 @@ const LANGUAGES = [
 
 /** These are keys of settings that have a scope of window or machine. */
 const workspaceSettingsKeys: Array<keyof Settings> = [
+  "cache",
   "codeLens",
   "config",
   "importMap",

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -11,6 +11,9 @@ import type {
  * contributions made by the extension.
  */
 export interface Settings {
+  /** Specify an explicit path to the `deno` cache instead of using DENO_DIR
+   * or the OS default. */
+  cache: string | null;
   /** Settings related to code lens. */
   codeLens: {
     implementations: boolean;
@@ -30,6 +33,8 @@ export interface Settings {
   internalDebug: boolean;
   /** Determine if the extension should be providing linting diagnostics. */
   lint: boolean;
+  /** Specify an explicit path to the `deno` binary. */
+  path: string | null;
   suggest: {
     autoImports: boolean;
     completeFunctionCalls: boolean;

--- a/package.json
+++ b/package.json
@@ -162,6 +162,12 @@
             "C:\\Program Files\\deno\\deno.exe"
           ]
         },
+        "deno.cache": {
+          "type": "string",
+          "default": null,
+          "markdownDescription": "A path to the cache directory for Deno. By default, the operating system's cache path plus `deno` is used, or the `DENO_DIR` environment variable, but if set, this path will be used instead.",
+          "scope": "window"
+        },
         "deno.codeLens.implementations": {
           "type": "boolean",
           "default": false,

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -28,12 +28,14 @@ const projectSettings = new Map<string, PluginSettings>();
 /** The default settings to assume to be true until a configuration message is
  * received from the extension. */
 const defaultSettings: Settings = {
+  cache: null,
   enable: false,
   codeLens: null,
   config: null,
   importMap: null,
   internalDebug: false,
   lint: false,
+  path: null,
   suggest: {
     autoImports: true,
     completeFunctionCalls: false,


### PR DESCRIPTION
Closes #287 

Provides a `deno.cache` setting which gets passed to the language server (and set as the `DENO_DIR` when running a test) which allows explicitly specifying a cache directory as part of the workspace configuration.

Requires https://github.com/denoland/deno/pull/11527 to do anything interesting.