### PR TITLE
chore: bump minimum version of Deno CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
 This extension adds support for using [Deno](https://deno.land/) with Visual
 Studio Code, powered by the Deno language server.
 
-> ⚠️ **Important:** You need to have a version of Deno CLI installed (v1.10.3 or
+> ⚠️ **Important:** You need to have a version of Deno CLI installed (v1.13.0 or
 > later). The extension requires the executable and by default will use the
 > environment path. You can explicitly set the path to the executable in Visual
 > Studio Code Settings for `deno.path`.
+>
 > [Check here](https://deno.land/#installation) for instructions on how to
 > install the Deno CLI.
 

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -9,4 +9,4 @@ export const LANGUAGE_CLIENT_NAME = "Deno Language Server";
 export const TS_LANGUAGE_FEATURES_EXTENSION =
   "vscode.typescript-language-features";
 /** The minimum version of Deno that this extension is designed to support. */
-export const SERVER_SEMVER = ">=1.10.3";
+export const SERVER_SEMVER = ">=1.13.0";


### PR DESCRIPTION
This updates to the min version to >= 1.13.0.  While this isn't technically true, v1.13 and later contains several stability and diagnostic fixes which we want to _nag_ people into having when using the LSP.