### PR TITLE
fix: debug config provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,32 +68,13 @@
     "debuggers": [
       {
         "type": "deno",
-        "label": "Deno: Run",
+        "label": "Deno",
         "runtime": "deno",
         "languages": [
           "typescript",
           "javascript",
           "typescriptreact",
           "javascriptreact"
-        ],
-        "configurationSnippets": [
-          {
-            "label": "Deno: Run",
-            "description": "Run and debug a Deno program.",
-            "body": {
-              "type": "pwa-node",
-              "request": "launch",
-              "program": "^\"\\${workspaceFolder}/${1:main.ts}\"",
-              "cwd": "^\"\\${workspaceFolder}\"",
-              "runtimeExecutable": "deno",
-              "runtimeArgs": [
-                "run",
-                "--inspect=127.0.0.1:${4:9229}",
-                "${3:--allow-all}"
-              ],
-              "attachSimplePort": "^${4:9229}"
-            }
-          }
         ]
       }
     ],


### PR DESCRIPTION
This deals with two issues that were causing challenges when configuring debug:

- There was a static config in the `package.json` which then causes the debug provider to not actually work.
- The debug provider did not take into account the context, meaning that if you were using an import map, a cache path, or a config file, none of those would be configured to automatically occur when starting debug or generating a `launch.json`.

In addition, the naming of the launch tasks have been adjusted to be better aligned with `Chrome` and `Node.js` debug configurations provided by vscode.