### PR TITLE
fix: use workspace root as current directory for executing test code …

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -244,7 +244,6 @@ export function test(
       type: tasks.TASK_TYPE,
       command: "test",
       args,
-      cwd: ".",
       env,
     };
 


### PR DESCRIPTION
…lens on remote container

Following test code placed in workspace root:
```typescript
import { dirname, fromFileUrl } from "https://deno.land/std@0.111.0/path/mod.ts";
import { assertEquals } from "https://deno.land/std@0.111.0/testing/asserts.ts";

Deno.test("cwd", () => {
  assertEquals(Deno.cwd(), dirname(fromFileUrl(import.meta.url)));
});
```
passes with test code lens on local machine, but fails on remote container.
Because extension running in remote container uses `/` as current directory.

The [API document](https://code.visualstudio.com/api/references/vscode-api#ProcessExecutionOptions) says:
> The current working directory of the executed program or shell. If omitted the tools current workspace root is used.

So, `cwd: "."` can be omitted.