### PR TITLE
chore: update min version

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -9,4 +9,4 @@ export const LANGUAGE_CLIENT_NAME = "Deno Language Server";
 export const TS_LANGUAGE_FEATURES_EXTENSION =
   "vscode.typescript-language-features";
 /** The minimum version of Deno that this extension is designed to support. */
-export const SERVER_SEMVER = ">=1.13.0";
+export const SERVER_SEMVER = ">=1.17.0";


### PR DESCRIPTION
Updating the minimum version of the Deno CLI.  The main reason is that Deno 1.17 ships with support for v2 of the registry suggestions, and we want to roll out a v2 version of the `deno.land/x` and `deno.land/std` registry, which would require Deno 1.17 or later to take full advantage of it.

I don't think we should publish a version of vscode_deno for a week or so, so that people organically upgrade to Deno 1.17 before we start "warning" them.