### PR TITLE
chore: use esbuild script for vscode tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       ],
       "preLaunchTask": {
         "type": "npm",
-        "script": "watch"
+        "script": "esbuild"
       }
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,22 +12,6 @@
       "problemMatcher": [
         "$tsc"
       ]
-    },
-    {
-      "type": "npm",
-      "script": "watch",
-      "isBackground": true,
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "presentation": {
-        "panel": "dedicated",
-        "reveal": "never"
-      },
-      "problemMatcher": [
-        "$tsc-watch"
-      ]
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
   "tasks": [
     {
       "type": "npm",
-      "script": "compile",
+      "script": "esbuild",
       "group": "build",
       "presentation": {
         "panel": "dedicated",

--- a/README.md
+++ b/README.md
@@ -147,8 +147,14 @@ steps:
 
 1. Open this folder in VS Code.
 2. Run `npm i`.
-3. Run `npm run compile`.
-4. Run the `Launch Client` launch task from the VSCode debug menu.
+3. Run the `Launch Client` launch task from the VSCode debug menu.
+
+After making changes to the extension you can use the restart button in the
+VSCode debug menu, this makes a new build and reloads the client.
+
+Note that if you already have the deno extension installed from the VSCode
+Marketplace, it will be replaced for the `Launch Client` instance only. So
+there's no need to uninstall your existing Deno extension.
 
 Most changes and feature enhancements do not require changes to the extension
 though, as most information comes from the Deno Language Server itself, which is

--- a/package.json
+++ b/package.json
@@ -445,7 +445,6 @@
     "test-compile": "tsc -b",
     "fmt": "deno fmt .vscode .github client/src media typescript-deno-plugin/src typescript-deno-plugin/*.md docs package.json tsconfig.json README.md CHANGELOG.md",
     "lint": "deno lint --unstable client/src typescript-deno-plugin/src docs",
-    "watch": "tsc -b -w",
     "postinstall": "cd typescript-deno-plugin && npm i && cd ../client && npm i && cd .."
   },
   "dependencies": {


### PR DESCRIPTION
Apologies if this breaks any existing workflows.
I'm not sure what setup is currently being used to work on this extension. But `npm run watch` didn't seem to work for me.
Either way, watching seems redundant since the extension host needs to be reloaded and this already makes a build before reloading.

I've also modified the readme, a build step like `npm run compile` is no longer required as the `Launch Client` already runs the build step for you.

I've also answered a few questions I had myself in the readme.

Fixes: #592