### PR TITLE
feat: support certificate related options

### DIFF
--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -45,10 +45,10 @@ export interface Settings {
     } | null;
   } | null;
   tlsCertificate: string | null;
-  unsafelyIgnoreCertificateErrors: boolean;
+  unsafelyIgnoreCertificateErrors: string[] | null;
   /** Determine if the extension should be type checking against the unstable
    * APIs. */
-  unstable: string[] | null;
+  unstable: boolean;
 }
 
 export interface PluginSettings {

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -48,7 +48,7 @@ export interface Settings {
   unsafelyIgnoreCertificateErrors: boolean;
   /** Determine if the extension should be type checking against the unstable
    * APIs. */
-  unstable: boolean;
+  unstable: string[] | null;
 }
 
 export interface PluginSettings {

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -12,6 +12,7 @@ export interface Settings {
   /** Specify an explicit path to the `deno` cache instead of using DENO_DIR
    * or the OS default. */
   cache: string | null;
+  certificateStores: string[] | null;
   /** Settings related to code lens. */
   codeLens: {
     implementations: boolean;
@@ -43,6 +44,8 @@ export interface Settings {
       hosts: Record<string, boolean>;
     } | null;
   } | null;
+  tlsCertificate: string | null;
+  unsafelyIgnoreCertificateErrors: boolean;
   /** Determine if the extension should be type checking against the unstable
    * APIs. */
   unstable: boolean;

--- a/package.json
+++ b/package.json
@@ -149,6 +149,15 @@
           "markdownDescription": "A path to the cache directory for Deno. By default, the operating system's cache path plus `deno` is used, or the `DENO_DIR` environment variable, but if set, this path will be used instead.",
           "scope": "window"
         },
+        "deno.certificateStores": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": null,
+          "markdownDescription": "A list of root certificate stores used to validate TLS certificates when fetching and caching remote resources. This overrides the `DENO_TLS_CA_STORE` environment variable if set.",
+          "scope": "window"
+        },
         "deno.codeLens.implementations": {
           "type": "boolean",
           "default": false,
@@ -256,6 +265,21 @@
           "examples": {
             "https://deno.land": true
           }
+        },
+        "deno.tlsCertificate": {
+          "type": "string",
+          "default": null,
+          "markdownDescription": "A path to a PEM certificate to use as the certificate authority when validating TLS certificates when fetching and caching remote resources. This is like using `--cert` on the Deno CLI and overrides the `DENO_CERT` environment variable if set.",
+          "scope": "window"
+        },
+        "deno.unsafelyIgnoreCertificateErrors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": null,
+          "markdownDescription": "**DANGER** disables verification of TLS certificates for the hosts provided. There is likely a better way to deal with any errors than use this option. This is like using `--unsafely-ignore-certificate-errors` in the Deno CLI.",
+          "scope": "window"
         },
         "deno.unstable": {
           "type": "boolean",

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -48,8 +48,8 @@ const defaultSettings: Settings = {
     },
   },
   tlsCertificate: null,
-  unsafelyIgnoreCertificateErrors: false,
-  unstable: null,
+  unsafelyIgnoreCertificateErrors: null,
+  unstable: false,
 };
 
 function updateSettings(

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -49,7 +49,7 @@ const defaultSettings: Settings = {
   },
   tlsCertificate: null,
   unsafelyIgnoreCertificateErrors: false,
-  unstable: false,
+  unstable: null,
 };
 
 function updateSettings(

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -29,6 +29,7 @@ const projectSettings = new Map<string, PluginSettings>();
  * received from the extension. */
 const defaultSettings: Settings = {
   cache: null,
+  certificateStores: null,
   enable: false,
   codeLens: null,
   config: null,
@@ -46,6 +47,8 @@ const defaultSettings: Settings = {
       hosts: {},
     },
   },
+  tlsCertificate: null,
+  unsafelyIgnoreCertificateErrors: false,
   unstable: false,
 };
 


### PR DESCRIPTION
This PR enables support for TLS certificate related options for registry completions and caching remote dependencies which are being added to CLI.

Ref: denoland/deno#13467