### PR TITLE
fix: send all workspace settings during initialisation

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -24,12 +24,17 @@ const LANGUAGES = [
 /** These are keys of settings that have a scope of window or machine. */
 const workspaceSettingsKeys: Array<keyof Settings> = [
   "cache",
+  "certificateStores",
   "codeLens",
   "config",
+  "enable",
   "importMap",
   "internalDebug",
   "lint",
+  "path",
   "suggest",
+  "tlsCertificate",
+  "unsafelyIgnoreCertificateErrors",
   "unstable",
 ];
 

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -7,6 +7,10 @@ import type { ConfigurationScope } from "vscode";
 /** When `vscode.WorkspaceSettings` get serialized, they keys of the
  * configuration are available.  This interface should mirror the configuration
  * contributions made by the extension.
+ *
+ * **WARNING** please ensure that the `workspaceSettingsKeys` contains all the
+ * top level keys of this, as they need to be sent to the server on
+ * initialization.
  */
 export interface Settings {
   /** Specify an explicit path to the `deno` cache instead of using DENO_DIR


### PR DESCRIPTION
I discovered this when working on the testing API.  Some keys were missing here, which meant that some settings weren't sent during initialisation, meaning they were stuck at their default values, even if they had been modified in the `settings.json` and wouldn't be changed unless the `settings.json` file was edited.