### PR TITLE
feat: support Deno enabling specified workspace paths

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       ],
       "preLaunchTask": {
         "type": "npm",
-        "script": "watch"
+        "script": "esbuild"
       }
     }
   ]

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+export const ENABLE_PATHS_ONLY = "enablePathsOnly";
 export const ENABLEMENT_FLAG = "deno:lspReady";
 export const EXTENSION_ID = "denoland.vscode-deno";
 export const EXTENSION_NS = "deno";

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
-export const ENABLE_PATHS_ONLY = "enablePathsOnly";
+export const ENABLE_PATHS = "enablePaths";
 export const ENABLEMENT_FLAG = "deno:lspReady";
 export const EXTENSION_ID = "denoland.vscode-deno";
 export const EXTENSION_NS = "deno";

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -29,6 +29,9 @@ export interface Settings {
   config: string | null;
   /** Is the extension enabled or not. */
   enable: boolean;
+  /** If set, indicates that only the paths in the workspace should be Deno
+   * enabled. */
+  enablePathsOnly: string[];
   /** A path to an import map that should be applied. */
   importMap: string | null;
   /** A flag that enables additional internal debug information to be printed
@@ -55,9 +58,17 @@ export interface Settings {
   unstable: boolean;
 }
 
+export interface EnabledOnlyPath {
+  /** The file system path of the workspace folder that is partially enabled. */
+  workspace: string;
+  /** The file system paths that are Deno enabled. */
+  paths: string[];
+}
+
 export interface PluginSettings {
-  workspace: Settings;
   documents: Record<string, DocumentSettings>;
+  enabledPaths: EnabledOnlyPath[];
+  workspace: Settings;
 }
 
 export interface DocumentSettings {

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -31,7 +31,7 @@ export interface Settings {
   enable: boolean;
   /** If set, indicates that only the paths in the workspace should be Deno
    * enabled. */
-  enablePathsOnly: string[];
+  enablePaths: string[];
   /** A path to an import map that should be applied. */
   importMap: string | null;
   /** A flag that enables additional internal debug information to be printed
@@ -58,7 +58,7 @@ export interface Settings {
   unstable: boolean;
 }
 
-export interface EnabledOnlyPath {
+export interface EnabledPaths {
   /** The file system path of the workspace folder that is partially enabled. */
   workspace: string;
   /** The file system paths that are Deno enabled. */
@@ -67,7 +67,7 @@ export interface EnabledOnlyPath {
 
 export interface PluginSettings {
   documents: Record<string, DocumentSettings>;
-  enabledPaths: EnabledOnlyPath[];
+  enabledPaths: EnabledPaths[];
   workspace: Settings;
 }
 

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -5,7 +5,11 @@ import type {
   LanguageClientOptions,
 } from "vscode-languageclient/node";
 import type { DenoServerInfo } from "./server_info";
-import type { DocumentSettings, Settings } from "./shared_types";
+import type {
+  DocumentSettings,
+  EnabledOnlyPath,
+  Settings,
+} from "./shared_types";
 import type { DenoStatusBar } from "./status_bar";
 
 export * from "./shared_types";
@@ -20,6 +24,7 @@ export interface DenoExtensionContext {
   clientOptions: LanguageClientOptions;
   /** A record of filepaths and their document settings. */
   documentSettings: Record<string, DocumentSettings>;
+  enabledPaths: EnabledOnlyPath[];
   serverInfo: DenoServerInfo | undefined;
   statusBar: DenoStatusBar;
   tsApi: TsApi;

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -5,11 +5,7 @@ import type {
   LanguageClientOptions,
 } from "vscode-languageclient/node";
 import type { DenoServerInfo } from "./server_info";
-import type {
-  DocumentSettings,
-  EnabledOnlyPath,
-  Settings,
-} from "./shared_types";
+import type { DocumentSettings, EnabledPaths, Settings } from "./shared_types";
 import type { DenoStatusBar } from "./status_bar";
 
 export * from "./shared_types";
@@ -24,7 +20,7 @@ export interface DenoExtensionContext {
   clientOptions: LanguageClientOptions;
   /** A record of filepaths and their document settings. */
   documentSettings: Record<string, DocumentSettings>;
-  enabledPaths: EnabledOnlyPath[];
+  enabledPaths: EnabledPaths[];
   serverInfo: DenoServerInfo | undefined;
   statusBar: DenoStatusBar;
   tsApi: TsApi;

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -58,7 +58,7 @@
       "version": "3.10.1",
       "license": "MIT",
       "devDependencies": {
-        "typescript": "^4.4.2"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "vscode": "^1.53.0"
@@ -79,15 +79,15 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
     "typescript-deno-plugin": {
       "version": "file:typescript-deno-plugin",
       "requires": {
-        "typescript": "^4.4.2"
+        "typescript": "^4.6.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -126,11 +126,25 @@
         "deno.enable": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Controls if the Deno Language Server is enabled. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services, and will use the Deno Language Server (`deno lsp`) instead.\n\n**Not recommended to be enabled globally.**",
+          "markdownDescription": "Controls if the Deno Language Server is enabled. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services, and will use the Deno Language Server instead.\n\n**Not recommended to be enabled globally.**",
           "scope": "resource",
           "examples": [
             true,
             false
+          ]
+        },
+        "deno.enablePathsOnly": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Controls if the Deno Language Server is enabled for a specific paths only. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services for the specified paths, and will use the Deno Language Server instead.\n\n\n\nThe workspace folder is used as the base for the supplied paths. When a value is set, the value of `\"deno.enable\"` is ignored.\n\nIf for example you have all your Deno code in `worker` path in your workspace, you add an item with the value of `./worker`.\n\n**Not recommended to be enabled in user settings.**",
+          "scope": "resource",
+          "examples": [
+            [
+              "./worker"
+            ]
           ]
         },
         "deno.path": {

--- a/package.json
+++ b/package.json
@@ -126,20 +126,20 @@
         "deno.enable": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Controls if the Deno Language Server is enabled. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services, and will use the Deno Language Server instead.\n\n**Not recommended to be enabled globally.**",
+          "markdownDescription": "Controls if the Deno Language Server is enabled. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services, and will use the Deno Language Server instead.\n\nIf you want to enable only part of your workspace folder, consider using `deno.enablePaths` setting instead.\n\n**Not recommended to be enabled globally.**",
           "scope": "resource",
           "examples": [
             true,
             false
           ]
         },
-        "deno.enablePathsOnly": {
+        "deno.enablePaths": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "Controls if the Deno Language Server is enabled for a specific paths only. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services for the specified paths, and will use the Deno Language Server instead.\n\n\n\nThe workspace folder is used as the base for the supplied paths. When a value is set, the value of `\"deno.enable\"` is ignored.\n\nIf for example you have all your Deno code in `worker` path in your workspace, you add an item with the value of `./worker`.\n\n**Not recommended to be enabled in user settings.**",
+          "markdownDescription": "Enables the Deno Language Server for specific paths, instead of for the whole workspace folder. This will disable the built in TypeScript/JavaScript language server for those paths.\n\nWhen a value is set, the value of `\"deno.enable\"` is ignored.\n\nThe workspace folder is used as the base for the supplied paths. If for example you have all your Deno code in `worker` path in your workspace, you can add an item with the value of `./worker`, and the Deno will only provide diagnostics for the files within `worker` or any of its sub paths.\n\n**Not recommended to be enabled in user settings.**",
           "scope": "resource",
           "examples": [
             [

--- a/typescript-deno-plugin/package-lock.json
+++ b/typescript-deno-plugin/package-lock.json
@@ -5,19 +5,20 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "typescript-deno-plugin",
 			"version": "3.10.1",
 			"license": "MIT",
 			"devDependencies": {
-				"typescript": "^4.4.2"
+				"typescript": "^4.6.2"
 			},
 			"engines": {
 				"vscode": "^1.53.0"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -30,9 +31,9 @@
 	},
 	"dependencies": {
 		"typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
 			"dev": true
 		}
 	}

--- a/typescript-deno-plugin/package.json
+++ b/typescript-deno-plugin/package.json
@@ -19,6 +19,6 @@
 		"vscode": "^1.53.0"
 	},
 	"devDependencies": {
-		"typescript": "^4.4.2"
+		"typescript": "^4.6.2"
 	}
 }

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -31,7 +31,7 @@ const defaultSettings: Settings = {
   cache: null,
   certificateStores: null,
   enable: false,
-  enablePathsOnly: [],
+  enablePaths: [],
   codeLens: null,
   config: null,
   importMap: null,


### PR DESCRIPTION
Closes: #633

This PR introduces the `deno.enablePathsOnly` configuration option. When set, vscode_deno will suppress built-in TypeScript/JavaScript language service features for the enabled paths within a workspace folder.  For example, setting `"deno.enablePathsOnly": ["./worker"]` would disable diagnostics and other language service features for any files in the `worker` path of the workspace (or its sub-folders).

This will require a similar feature in the Deno language server to only provide language service features for the enabled paths.