### PR TITLE
feat: support config file tasks

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -144,6 +144,7 @@ export function startLanguageServer(
     extensionContext.serverInfo = new DenoServerInfo(
       client.initializeResult?.serverInfo,
     );
+    extensionContext.serverCapabilities = client.initializeResult?.capabilities;
     extensionContext.statusBar.refresh(extensionContext);
 
     context.subscriptions.push(
@@ -254,8 +255,9 @@ export function test(
 
     assert(vscode.workspace.workspaceFolders);
     const target = vscode.workspace.workspaceFolders[0];
-    const task = await tasks.buildDenoTask(
+    const task = tasks.buildDenoTask(
       target,
+      await getDenoCommand(),
       definition,
       `test "${name}"`,
       args,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -234,7 +234,7 @@ export async function activate(
   );
 
   // Activate the task provider.
-  context.subscriptions.push(activateTaskProvider());
+  context.subscriptions.push(activateTaskProvider(extensionContext));
 
   // Register any commands.
   const registerCommand = createRegisterCommand(context);

--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -34,6 +34,25 @@ export const registryState = new NotificationType<RegistryStateParams>(
   "deno/registryState",
 );
 
+export interface TaskParams {
+  scope?: string;
+}
+
+export interface TaskRequestResponse {
+  name: string;
+  detail: string;
+}
+
+/** Requests any tasks from the language server that the language server is
+ * aware of, which are defined in a Deno configuration file. */
+export const task = new RequestType<
+  TaskParams,
+  TaskRequestResponse[] | undefined,
+  void
+>(
+  "deno/task",
+);
+
 export interface VirtualTextDocumentParams {
   textDocument: TextDocumentIdentifier;
 }

--- a/client/src/tasks.ts
+++ b/client/src/tasks.ts
@@ -1,11 +1,19 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+import { task as taskReq } from "./lsp_extensions";
+import type { DenoExtensionContext } from "./types";
 import { getDenoCommand } from "./util";
 
 import * as vscode from "vscode";
 
 export const TASK_TYPE = "deno";
 export const TASK_SOURCE = "deno";
+export const TASK_CONFIG_SOURCE = "deno task";
+
+interface DenoConfigTaskDefinition extends vscode.TaskDefinition {
+  name: string;
+  detail?: string;
+}
 
 export interface DenoTaskDefinition extends vscode.TaskDefinition {
   command: string;
@@ -14,15 +22,16 @@ export interface DenoTaskDefinition extends vscode.TaskDefinition {
   env?: Record<string, string>;
 }
 
-export async function buildDenoTask(
+export function buildDenoTask(
   target: vscode.WorkspaceFolder,
+  process: string,
   definition: DenoTaskDefinition,
   name: string,
   args: string[],
   problemMatchers: string[],
-): Promise<vscode.Task> {
+): vscode.Task {
   const exec = new vscode.ProcessExecution(
-    await getDenoCommand(),
+    process,
     args,
     definition,
   );
@@ -37,12 +46,50 @@ export async function buildDenoTask(
   );
 }
 
+function buildDenoConfigTask(
+  scope: vscode.WorkspaceFolder,
+  process: string,
+  name: string,
+  detail?: string,
+): vscode.Task {
+  const execution = new vscode.ProcessExecution(process, ["task", name]);
+
+  const task = new vscode.Task(
+    { type: TASK_TYPE, name, detail },
+    scope,
+    name,
+    TASK_CONFIG_SOURCE,
+    execution,
+    ["$deno"],
+  );
+  task.detail = detail;
+  return task;
+}
+
+function isDenoTaskDefinition(
+  value: vscode.TaskDefinition,
+): value is DenoTaskDefinition {
+  return value.type === TASK_TYPE && typeof value.command !== "undefined";
+}
+
+function isDenoConfigTaskDefinition(
+  value: vscode.TaskDefinition,
+): value is DenoConfigTaskDefinition {
+  return value.type === TASK_TYPE && typeof value.name !== "undefined";
+}
+
 function isWorkspaceFolder(value: unknown): value is vscode.WorkspaceFolder {
   return typeof value === "object" && value != null &&
     (value as vscode.WorkspaceFolder).name !== undefined;
 }
 
 class DenoTaskProvider implements vscode.TaskProvider {
+  #extensionContext: DenoExtensionContext;
+
+  constructor(extensionContext: DenoExtensionContext) {
+    this.#extensionContext = extensionContext;
+  }
+
   async provideTasks(): Promise<vscode.Task[]> {
     const defs = [
       {
@@ -74,10 +121,13 @@ class DenoTaskProvider implements vscode.TaskProvider {
     ];
 
     const tasks: vscode.Task[] = [];
+
+    const process = await getDenoCommand();
     for (const workspaceFolder of vscode.workspace.workspaceFolders ?? []) {
       for (const { command, group, problemMatchers } of defs) {
-        const task = await buildDenoTask(
+        const task = buildDenoTask(
           workspaceFolder,
+          process,
           { type: TASK_TYPE, command },
           command,
           [command],
@@ -87,28 +137,59 @@ class DenoTaskProvider implements vscode.TaskProvider {
         tasks.push(task);
       }
     }
+
+    // we retrieve config tasks from the language server, if the language server
+    // supports the capability
+    const client = this.#extensionContext.client;
+    const supportsConfigTasks = this.#extensionContext.serverCapabilities
+      ?.experimental?.denoConfigTasks;
+    if (client && supportsConfigTasks) {
+      const configTasks = await client.sendRequest(taskReq, {});
+      for (const workspaceFolder of vscode.workspace.workspaceFolders ?? []) {
+        if (configTasks) {
+          for (const { name, detail } of configTasks) {
+            tasks.push(
+              buildDenoConfigTask(workspaceFolder, process, name, detail),
+            );
+          }
+        }
+      }
+    }
+
     return tasks;
   }
 
   async resolveTask(task: vscode.Task): Promise<vscode.Task | undefined> {
-    const definition = task.definition as DenoTaskDefinition;
+    const { definition } = task;
 
-    if (definition.type === TASK_TYPE && definition.command) {
+    if (isDenoTaskDefinition(definition)) {
       const args = [definition.command].concat(definition.args ?? []);
       if (isWorkspaceFolder(task.scope)) {
-        return await buildDenoTask(
+        return buildDenoTask(
           task.scope,
+          await getDenoCommand(),
           definition,
           task.name,
           args,
           task.problemMatchers,
         );
       }
+    } else if (isDenoConfigTaskDefinition(definition)) {
+      if (isWorkspaceFolder(task.scope)) {
+        return buildDenoConfigTask(
+          task.scope,
+          await getDenoCommand(),
+          definition.name,
+          definition.detail,
+        );
+      }
     }
   }
 }
 
-export function activateTaskProvider(): vscode.Disposable {
-  const provider = new DenoTaskProvider();
+export function activateTaskProvider(
+  extensionContext: DenoExtensionContext,
+): vscode.Disposable {
+  const provider = new DenoTaskProvider(extensionContext);
   return vscode.tasks.registerTaskProvider(TASK_TYPE, provider);
 }

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -8,11 +8,19 @@ import type { DenoServerInfo } from "./server_info";
 import type { DocumentSettings, EnabledPaths, Settings } from "./shared_types";
 import type { DenoStatusBar } from "./status_bar";
 
+import type { ServerCapabilities } from "vscode-languageclient";
+
 export * from "./shared_types";
 
 export interface TsApi {
   /** Update the typescript-deno-plugin with settings. */
   refresh(): void;
+}
+
+interface DenoExperimental {
+  /** Support for the `deno/task` request, which returns any tasks that are
+   * defined in configuration files. */
+  denoConfigTasks?: boolean;
 }
 
 export interface DenoExtensionContext {
@@ -22,6 +30,10 @@ export interface DenoExtensionContext {
   documentSettings: Record<string, DocumentSettings>;
   enabledPaths: EnabledPaths[];
   serverInfo: DenoServerInfo | undefined;
+  /** The capabilities returned from the server. */
+  serverCapabilities:
+    | ServerCapabilities<DenoExperimental>
+    | undefined;
   statusBar: DenoStatusBar;
   tsApi: TsApi;
   /** The current workspace settings. */


### PR DESCRIPTION
This is the vscode_deno implementation of being able to provide tasks defined in a Deno configuration file:

https://user-images.githubusercontent.com/1282577/160353997-60a72c99-5818-423a-a5b3-c8805ba4f868.mp4

It requires a yet to be raised PR for Deno CLI which provides the `denoConfigTasks` feature.

Ref: denoland/deno#13910