### PR TITLE
fix: Catching errors, wile fetching config tasks from language server

### DIFF
--- a/client/src/tasks.ts
+++ b/client/src/tasks.ts
@@ -144,15 +144,19 @@ class DenoTaskProvider implements vscode.TaskProvider {
     const supportsConfigTasks = this.#extensionContext.serverCapabilities
       ?.experimental?.denoConfigTasks;
     if (client && supportsConfigTasks) {
-      const configTasks = await client.sendRequest(taskReq, {});
-      for (const workspaceFolder of vscode.workspace.workspaceFolders ?? []) {
-        if (configTasks) {
-          for (const { name, detail } of configTasks) {
-            tasks.push(
-              buildDenoConfigTask(workspaceFolder, process, name, detail),
-            );
+      try {
+        const configTasks = await client.sendRequest(taskReq, {});
+        for (const workspaceFolder of vscode.workspace.workspaceFolders ?? []) {
+          if (configTasks) {
+            for (const { name, detail } of configTasks) {
+              tasks.push(
+                buildDenoConfigTask(workspaceFolder, process, name, detail),
+              );
+            }
           }
         }
+      } catch (err) {
+        vscode.window.showErrorMessage("Failed to retrieve config tasks from deno")
       }
     }
 


### PR DESCRIPTION
This aims to fix #654.
The problem is caused by an unhandled promise rejection. This is the stacktrace I got:
```
'Error: Unexpected params: {}
at handleResponse (c:\\work\\vscode_deno\\client\\dist\\main.js:4396:40)
at processMessageQueue (c:\\work\\vscode_deno\\client\\dist\\main.js:4234:13)
at Immediate.<anonymous> (c:\\work\\vscode_deno\\client\\dist\\main.js:4220:11)
at processImmediate (node:internal/timers:464:21)
at process.callbackTrampoline (node:internal/async_hooks:130:17)'
```

I know that isn't a fix for the real root cause, just a quick patch for the problem, but without this it's really hard to use vscode (at least for tasks) when the deno extension is active.

I you provide me with hints how to debug or test the language server, or where to look for fetching these tasks, I might investigate it as well.
Showing an error popup each time build tasks are requested may be a bit intrusive, but at least users can see, that someting isn't working with deno config tasks