### PR TITLE
Exclude demo image from extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,7 +12,6 @@ typescript-deno-plugin
 node_modules
 !node_modules/typescript-deno-plugin/dist/*.js
 !node_modules/typescript-deno-plugin/package.json
-!screenshots/basic_usage.gif
 client
 !client/dist/*.js
 !client/package.json


### PR DESCRIPTION
I noticed a demo image isn't excluded from the extension package, hence this pull request. With this change, package size is down from 1.59MB to 390.76KB.

It does not break the links as VSCode rewrites assets in README to use GitHub links.