### PR TITLE
"Failed to retrieve config tasks."

### DIFF
--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -39,10 +39,6 @@ export const registryState = new NotificationType<RegistryStateParams>(
   "deno/registryState",
 );
 
-export interface TaskParams {
-  scope?: string;
-}
-
 export interface TaskRequestResponse {
   name: string;
   detail: string;
@@ -50,8 +46,7 @@ export interface TaskRequestResponse {
 
 /** Requests any tasks from the language server that the language server is
  * aware of, which are defined in a Deno configuration file. */
-export const task = new RequestType<
-  TaskParams,
+export const task = new RequestType0<
   TaskRequestResponse[] | undefined,
   void
 >(

--- a/client/src/tasks.ts
+++ b/client/src/tasks.ts
@@ -145,7 +145,7 @@ class DenoTaskProvider implements vscode.TaskProvider {
       ?.experimental?.denoConfigTasks;
     if (client && supportsConfigTasks) {
       try {
-        const configTasks = await client.sendRequest(taskReq, {});
+        const configTasks = await client.sendRequest(taskReq);
         for (const workspaceFolder of vscode.workspace.workspaceFolders ?? []) {
           if (configTasks) {
             for (const { name, detail } of configTasks) {


### PR DESCRIPTION
The `deno/task` LSP request expects no parameters. Current code displays a "Failed to retrieve config tasks." error message as the request fails every time I launch if `deno.unstable` is true.