### PR TITLE
fix: send inlay hints config on init

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -36,6 +36,7 @@ const workspaceSettingsKeys: Array<keyof Settings> = [
   "enable",
   "enablePaths",
   "importMap",
+  "inlayHints",
   "internalDebug",
   "lint",
   "path",

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -34,6 +34,29 @@ export interface Settings {
   enablePaths: string[];
   /** A path to an import map that should be applied. */
   importMap: string | null;
+  /** Options related to the display of inlay hints. */
+  inlayHints: {
+    parameterNames: {
+      /** Enable/disable inlay hints for parameter names. */
+      enabled: "none" | "literals" | "all";
+      /** Do not display an inlay hint when the argument name matches the parameter. */
+      suppressWhenArgumentMatchesName: boolean;
+    } | null;
+    /** Enable/disable inlay hints for implicit parameter types. */
+    parameterTypes: { enabled: boolean } | null;
+    variableTypes: {
+      /** Enable/disable inlay hints for implicit variable types. */
+      enabled: boolean;
+      /** Suppress type hints where the variable name matches the implicit type. */
+      suppressWhenTypeMatchesName: boolean;
+    } | null;
+    /** Enable/disable inlay hints for implicit property declarations. */
+    propertyDeclarationTypes: { enabled: boolean } | null;
+    /** Enable/disable inlay hints for implicit function return types. */
+    functionLikeReturnTypes: { enabled: boolean } | null;
+    /** Enable/disable inlay hints for enum values. */
+    enumMemberValues: { enabled: boolean } | null;
+  } | null;
   /** A flag that enables additional internal debug information to be printed
    * to the _Deno Language Server_ output. */
   internalDebug: boolean;

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -35,6 +35,7 @@ const defaultSettings: Settings = {
   codeLens: null,
   config: null,
   importMap: null,
+  inlayHints: null,
   internalDebug: false,
   lint: false,
   path: null,


### PR DESCRIPTION
This fixes an issue where the inlay hint configuration is not available at startup.