### PR TITLE
fix: enablePaths on Windows

### DIFF
--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -79,6 +79,9 @@ class Plugin implements ts.server.PluginModule {
 
   // determines if a specific filename is Deno enabled or not.
   #fileNameDenoEnabled(fileName: string): boolean {
+    if (process.platform === "win32") {
+      fileName = fileName.replace(/\//g, "\\");
+    }
     const settings = projectSettings.get(this.#projectName);
     if (settings?.enabledPaths) {
       const paths = settings.enabledPaths.find(({ workspace }) =>


### PR DESCRIPTION
Path separators on Windows caused an incorrect behavior in `#fileNameDenoEnabled` that resulted in a non-functioning `deno.enablePaths` setting on Windows. This fixes #668.