### PR TITLE
Use "node" launch type instead of "pwa-node"

### DIFF
--- a/client/src/debug_config_provider.ts
+++ b/client/src/debug_config_provider.ts
@@ -39,7 +39,7 @@ export class DenoDebugConfigurationProvider
       {
         request: "launch",
         name: "Launch Program",
-        type: "pwa-node",
+        type: "node",
         program: "${workspaceFolder}/main.ts",
         cwd: "${workspaceFolder}",
         env: this.#getEnv(),
@@ -73,7 +73,7 @@ export class DenoDebugConfigurationProvider
         vscode.debug.startDebugging(workspace, {
           request: "launch",
           name: "Launch Program",
-          type: "pwa-node",
+          type: "node",
           program: "${file}",
           env: this.#getEnv(),
           runtimeExecutable: await getDenoCommandName(),


### PR DESCRIPTION
Silences the warning "please use type node instead"