### PR TITLE
feat: make `--inspect-wait` default when debugging

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -242,7 +242,7 @@ export async function activate(
   context.subscriptions.push(
     vscode.debug.registerDebugConfigurationProvider(
       "deno",
-      new DenoDebugConfigurationProvider(getWorkspaceSettings),
+      new DenoDebugConfigurationProvider(extensionContext),
     ),
   );
 


### PR DESCRIPTION
Fixes #774 and possibly makes #608 obsolete.

Please let me know if I should change or test something specific. I've tested with current and old Deno versions.

I had to change the argument received in the constructor because I needed to check the version of the Deno Server.

From what I observed (code below), `getSettings === extensionContext.clientOptions.initializationOptions`, so I adjusted the calls.

https://github.com/denoland/vscode_deno/blob/5ab30d8c7e966add3db6a4ecef1cfccd49cf0d3b/client/src/extension.ts#L198

https://github.com/denoland/vscode_deno/blob/5ab30d8c7e966add3db6a4ecef1cfccd49cf0d3b/client/src/extension.ts#L245