### PR TITLE
feat: make `--inspect-brk` default in older versions of Deno

### DIFF
--- a/client/src/debug_config_provider.ts
+++ b/client/src/debug_config_provider.ts
@@ -37,7 +37,7 @@ export class DenoDebugConfigurationProvider
     if (version && semver.valid(version) && semver.satisfies(version, ">=1.29.0")) {
       return "--inspect-wait"
     } else {
-      return "--inspect";
+      return "--inspect-brk";
     }
   }
 


### PR DESCRIPTION
As requested https://github.com/denoland/vscode_deno/pull/775#discussion_r1057971783