### PR TITLE
feat: cache on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ The extension provides several commands:
   > ℹ️ &nbsp; If there are missing dependencies in a module, the extension will
   > provide a quick fix to fetch and cache those dependencies, which invokes
   > this command for you.
+
 - _Deno: Initialize Workspace Configuration_ - will enabled Deno on the current
   workspace and allow you to choose to enable linting and Deno _unstable_ API
   options.
 - _Deno: Language Server Status_ - displays a page of information about the
   status of the Deno Language Server. Useful when submitting a bug about the
-  extension or the language server. _ _Deno: Reload Import Registries Cache_ -
+  extension or the language server. \_ _Deno: Reload Import Registries Cache_ -
   reload any cached responses from the configured import registries.
 - _Deno: Welcome_ - displays the information document that appears when the
   extension is first installed.
@@ -137,6 +138,9 @@ extension has the following configuration options:
 - `deno.cache`: Controls the location of the cache (`DENO_DIR`) for the Deno
   language server. This is similar to setting the `DENO_DIR` environment
   variable on the command line.
+- `deno.cacheOnSave`: Controls if the Deno cache is enabled to cache on save
+  automatically. When enabled, the extension will cache the active document and
+  its dependencies using the Deno cache automatically when the user saves it.
 - `deno.codeLens.implementations`: Enables or disables the display of code lens
   information for implementations for items in the code. _boolean, default
   `false`_

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -182,6 +182,17 @@ function handleTextDocumentSave(doc: vscode.TextDocument) {
     return;
   }
   if (extensionContext.workspaceSettings.cacheOnSave) {
+    const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+    if (
+      !diagnostics.some((it) =>
+        it.code === "no-cache" || it.code === "no-cache-npm"
+      )
+    ) {
+      console.log("no-cache diagnostic not found, skipping cache...");
+      return;
+    }
+
+    console.log("no-cache diagnostic found, caching...");
     vscode.commands.executeCommand("deno.cache");
   }
 }
@@ -247,7 +258,7 @@ export async function activate(
     handleTextDocumentSave,
     extensionContext,
     context.subscriptions,
-  )
+  );
 
   extensionContext.statusBar = new DenoStatusBar();
   context.subscriptions.push(extensionContext.statusBar);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -188,7 +188,6 @@ function handleTextDocumentSave(doc: vscode.TextDocument) {
         it.code === "no-cache" || it.code === "no-cache-npm"
       )
     ) {
-      console.log("no-cache diagnostic not found, skipping cache...");
       return;
     }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -30,6 +30,7 @@ const LANGUAGES = [
 /** These are keys of settings that have a scope of window or machine. */
 const workspaceSettingsKeys: Array<keyof Settings> = [
   "cache",
+  "cacheOnSave",
   "certificateStores",
   "codeLens",
   "config",
@@ -176,6 +177,15 @@ function handleDocumentOpen(...documents: vscode.TextDocument[]) {
   }
 }
 
+function handleTextDocumentSave(doc: vscode.TextDocument) {
+  if (!LANGUAGES.includes(doc.languageId)) {
+    return;
+  }
+  if (extensionContext.workspaceSettings.cacheOnSave) {
+    vscode.commands.executeCommand("deno.cache");
+  }
+}
+
 const extensionContext = {} as DenoExtensionContext;
 
 /** When the extension activates, this function is called with the extension
@@ -232,6 +242,12 @@ export async function activate(
     extensionContext,
     context.subscriptions,
   );
+
+  vscode.workspace.onDidSaveTextDocument(
+    handleTextDocumentSave,
+    extensionContext,
+    context.subscriptions,
+  )
 
   extensionContext.statusBar = new DenoStatusBar();
   context.subscriptions.push(extensionContext.statusBar);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -78,7 +78,8 @@ function configToResourceSettings(
     const value = config.inspect(key);
     assert(value);
     resourceSettings[key] = value.workspaceFolderLanguageValue ??
-      value.workspaceFolderValue ?? value.workspaceLanguageValue ??
+      value.workspaceFolderValue ??
+      value.workspaceLanguageValue ??
       value.workspaceValue ??
       value.globalValue ??
       value.defaultValue;
@@ -100,8 +101,8 @@ function getEnabledPaths(): EnabledPaths[] {
     if (!enabledPaths || !enabledPaths.length) {
       continue;
     }
-    const paths = enabledPaths.map((folder) =>
-      vscode.Uri.joinPath(workspaceFolder.uri, folder).fsPath
+    const paths = enabledPaths.map(
+      (folder) => vscode.Uri.joinPath(workspaceFolder.uri, folder).fsPath,
     );
     items.push({
       workspace: workspaceFolder.uri.fsPath,
@@ -184,14 +185,13 @@ function handleTextDocumentSave(doc: vscode.TextDocument) {
   if (extensionContext.workspaceSettings.cacheOnSave) {
     const diagnostics = vscode.languages.getDiagnostics(doc.uri);
     if (
-      !diagnostics.some((it) =>
-        it.code === "no-cache" || it.code === "no-cache-npm"
+      !diagnostics.some(
+        (it) => it.code === "no-cache" || it.code === "no-cache-npm",
       )
     ) {
       return;
     }
 
-    console.log("no-cache diagnostic found, caching...");
     vscode.commands.executeCommand("deno.cache");
   }
 }

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -32,6 +32,8 @@ export interface Settings {
   maxTsServerMemory: number | null;
   /** Is the extension enabled or not. */
   enable: boolean;
+  /** Controls if the Deno cache is enabled on save. When enabled, the extension will cache the active document and its dependencies using the Deno cache. */
+  cacheOnSave: boolean;
   /** If set, indicates that only the paths in the workspace should be Deno
    * enabled. */
   enablePaths: string[];

--- a/package.json
+++ b/package.json
@@ -133,6 +133,16 @@
             false
           ]
         },
+        "deno.cacheOnSave": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Controls if the Deno cache is enabled on save. When enabled, the extension will cache the active document and its dependencies using the Deno cache.",
+          "scope": "resource",
+          "examples": [
+            true,
+            false
+          ]
+        },
         "deno.enablePaths": {
           "type": "array",
           "items": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
         },
         "deno.cacheOnSave": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "markdownDescription": "Controls if the Deno cache is enabled to cache on save automatically. When enabled, the extension will cache the active document and its dependencies using the Deno cache automatically when the user saves it.",
           "scope": "resource",
           "examples": [

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
         "deno.cacheOnSave": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Controls if the Deno cache is enabled on save. When enabled, the extension will cache the active document and its dependencies using the Deno cache.",
+          "markdownDescription": "Controls if the Deno cache is enabled to cache on save automatically. When enabled, the extension will cache the active document and its dependencies using the Deno cache automatically when the user saves it.",
           "scope": "resource",
           "examples": [
             true,

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -29,6 +29,7 @@ const projectSettings = new Map<string, PluginSettings>();
  * received from the extension. */
 const defaultSettings: Settings = {
   cache: null,
+  cacheOnSave: true,
   certificateStores: null,
   enable: false,
   enablePaths: [],

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -29,7 +29,7 @@ const projectSettings = new Map<string, PluginSettings>();
  * received from the extension. */
 const defaultSettings: Settings = {
   cache: null,
-  cacheOnSave: true,
+  cacheOnSave: false,
   certificateStores: null,
   enable: false,
   enablePaths: [],


### PR DESCRIPTION
This PR added a feature called cache on save that includes:

- A setting entry `deno.cacheOnSave` of type of bool, defaults to `true`
- A listener of `onDidSaveTextDocument` that will call `deno.cache` command if `deno.cacheOnSave` is set to `true`

closes: #826