### PR TITLE
fix: update default import suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -346,9 +346,7 @@
         "deno.suggest.imports.hosts": {
           "type": "object",
           "default": {
-            "https://deno.land": true,
-            "https://x.nest.land": true,
-            "https://crux.land": true
+            "https://deno.land": true
           },
           "markdownDescription": "Controls which hosts are enabled for import suggestions.",
           "scope": "window",


### PR DESCRIPTION
The default import suggestions should just be for deno.land in order to recommend to users to just use that.