### PR TITLE
add "registry" Settings option

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -41,6 +41,7 @@ const workspaceSettingsKeys: Array<keyof Settings> = [
   "inlayHints",
   "internalDebug",
   "lint",
+  "npmRegistry",
   "path",
   "suggest",
   "testing",

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -65,6 +65,8 @@ export interface Settings {
   internalDebug: boolean;
   /** Determine if the extension should be providing linting diagnostics. */
   lint: boolean;
+  /** A custom npm registry used for npm specifiers. */
+  npmRegistry: string | null;
   /** Specify an explicit path to the `deno` binary. */
   path: string | null;
   suggest: {

--- a/package.json
+++ b/package.json
@@ -157,6 +157,15 @@
             "C:\\Program Files\\deno\\deno.exe"
           ]
         },
+        "deno.npmRegistry": {
+          "type": "string",
+          "default": null,
+          "markdownDescription": "A custom npm registry used for npm specifiers. By default, use the global https://www.npmjs.com/ registry.",
+          "scope": "window",
+          "examples": [
+            "https://artifactory.mycompany.net/artifactory/api/npm/virtual-npm"
+          ]
+        },
         "deno.cache": {
           "type": "string",
           "default": null,

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -40,6 +40,7 @@ const defaultSettings: Settings = {
   inlayHints: null,
   internalDebug: false,
   lint: false,
+  npmRegistry: null,
   path: null,
   suggest: {
     autoImports: true,


### PR DESCRIPTION
Makes the LSP setting added in https://github.com/denoland/deno/pull/19317 configurable in the VS Code extension 