### PR TITLE
feat: show output panel on status bar click

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -364,3 +364,12 @@ export function welcome(
     WelcomePanel.createOrShow(context.extensionUri);
   };
 }
+
+export function openOutput(
+  _context: vscode.ExtensionContext,
+  extensionContext: DenoExtensionContext,
+) {
+  return () => {
+    extensionContext.outputChannel.show(true);
+  };
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -264,6 +264,7 @@ export async function activate(
   registerCommand("status", commands.status);
   registerCommand("test", commands.test);
   registerCommand("welcome", commands.welcome);
+  registerCommand("openOutput", commands.openOutput);
 
   extensionContext.tsApi = getTsApi(() => ({
     documents: extensionContext.documentSettings,

--- a/client/src/status_bar.ts
+++ b/client/src/status_bar.ts
@@ -12,6 +12,7 @@ export class DenoStatusBar {
       vscode.StatusBarAlignment.Right,
       0,
     );
+    this.#inner.command = "deno.openOutput";
   }
 
   dispose() {


### PR DESCRIPTION
This PR adds a click handler to the status bar item which opens the output panel. Noticed that the prettier extension has this too and it's kinda neat from a UX perspective for debugging. Otherwise you'd need to open the output panel manually and pick the appropriate extension from the dropdown menu.

<img width="810" alt="Screenshot 2023-06-06 at 11 05 32" src="https://github.com/denoland/vscode_deno/assets/1062408/93a91d68-bd01-4a2e-8575-17470059fff3">
