### PR TITLE
feat: allow --inspect-wait when debugging test

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -19,7 +19,12 @@ import * as tasks from "./tasks";
 import { DenoTestController, TestingFeature } from "./testing";
 import type { DenoExtensionContext, TestCommandOptions } from "./types";
 import { WelcomePanel } from "./welcome";
-import { assert, getDenoCommandName, getDenoCommandPath } from "./util";
+import {
+  assert,
+  getDenoCommandName,
+  getDenoCommandPath,
+  getInspectArg,
+} from "./util";
 import { registryState } from "./lsp_extensions";
 import { createRegistryStateHandler } from "./notification_handlers";
 import { DenoServerInfo } from "./server_info";
@@ -284,7 +289,7 @@ export function status(
 
 export function test(
   _context: vscode.ExtensionContext,
-  _extensionContext: DenoExtensionContext,
+  extensionContext: DenoExtensionContext,
 ): Callback {
   return async (uriStr: string, name: string, options: TestCommandOptions) => {
     const uri = vscode.Uri.parse(uriStr, true);
@@ -297,7 +302,7 @@ export function test(
       testArgs.push("--unstable");
     }
     if (options?.inspect) {
-      testArgs.push("--inspect-brk");
+      testArgs.push(getInspectArg(extensionContext.serverInfo?.version));
     }
     if (!testArgs.includes("--import-map")) {
       const importMap: string | undefined | null = config.get("importMap");

--- a/client/src/debug_config_provider.ts
+++ b/client/src/debug_config_provider.ts
@@ -1,9 +1,8 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import type { DenoExtensionContext } from "./types";
-import { getDenoCommandName } from "./util";
-import * as semver from "semver";
 import * as vscode from "vscode";
+import type { DenoExtensionContext } from "./types";
+import { getDenoCommandName, getInspectArg } from "./util";
 
 export class DenoDebugConfigurationProvider
   implements vscode.DebugConfigurationProvider {
@@ -34,15 +33,7 @@ export class DenoDebugConfigurationProvider
   }
 
   #getInspectArg() {
-    const version = this.#extensionContext.serverInfo?.version;
-
-    if (
-      version && semver.valid(version) && semver.satisfies(version, ">=1.29.0")
-    ) {
-      return "--inspect-wait";
-    } else {
-      return "--inspect-brk";
-    }
+    return getInspectArg(this.#extensionContext.serverInfo?.version);
   }
 
   constructor(extensionContext: DenoExtensionContext) {

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -6,6 +6,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as process from "process";
+import * as semver from "semver";
 import * as vscode from "vscode";
 
 /** Assert that the condition is "truthy", otherwise throw. */
@@ -113,4 +114,15 @@ function fileExists(executableFilePath: string): Promise<boolean> {
     // ignore all errors
     return false;
   });
+}
+
+export function getInspectArg(denoVersion?: string) {
+  if (
+    denoVersion && semver.valid(denoVersion) &&
+    semver.satisfies(denoVersion, ">=1.29.0")
+  ) {
+    return "--inspect-wait";
+  } else {
+    return "--inspect-brk";
+  }
 }


### PR DESCRIPTION
### Motivation

vscode_deno offers a code lens action "Run Test | Debug". However when clicking the "Debug", it triggers a breakpoint which an user did not set.

### Changes made

- Unified the logic for selecting the appropriate debugging flag (`--inspect-brk` or `--inspect-wait`) based on the behavior of pull request #775.

### Testing

Tested on windows, not sure about other OS but I think there should be no problem.

### Notes for Reviewers

The breakpoint continues to be triggered only on the first time and not from the second. I'm not sure about underlying cause.