### PR TITLE
fix: properly detect 1.37.0

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -69,7 +69,7 @@ function configToWorkspaceSettings(
     // TODO(nayeemrmn): Deno LSP versions < 1.37.0 require `deno.enable` to be
     // non-null. Eventually remove this.
     if (
-      semver.lt(extensionContext.serverInfo?.version ?? "1.0.0", "1.37.0") &&
+      semver.lt(extensionContext.serverInfo?.version ?? "1.0.0", "1.37.0-rc") &&
       key == "enable"
     ) {
       workspaceSettings[key] ??= false;
@@ -317,7 +317,7 @@ export async function activate(
   await commands.startLanguageServer(context, extensionContext)();
   // TODO(nayeemrmn): Deno LSP versions < 1.37.0 has different compat logic.
   // We restart here if it's detected. Eventually remove this.
-  if (!semver.lt(extensionContext.serverInfo!.version, "1.37.0")) {
+  if (!semver.lt(extensionContext.serverInfo!.version, "1.37.0-rc")) {
     extensionContext.workspaceSettings = getWorkspaceSettings();
     await commands.startLanguageServer(context, extensionContext)();
   }


### PR DESCRIPTION
The check added in https://github.com/denoland/vscode_deno/commit/b6a0d19ca12f0439e12d3387de61d7d693431697 will fail to detect 1.37.0 when creating the initialization options, because of course we don't have server version info yet at that point. So we check it again after starting the language server and maybe restart.

Enable for release candidates of 1.37.0 as well.

Also we weren't signalling config changes to the server for `deno.enable` and `deno.enablePaths`.