### PR TITLE
fix: default "deno.enable" to false temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
       "properties": {
         "deno.enable": {
           "type": "boolean",
-          "default": null,
+          "default": false,
           "markdownDescription": "Controls if the Deno Language Server is enabled. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services, and will use the Deno Language Server instead.\n\nIf omitted, your preference will be inferred as true if there is a `deno.json[c]` at your workspace root and false if not.\n\nIf you want to enable only part of your workspace folder, consider using `deno.enablePaths` setting instead.\n\n**Not recommended to be enabled globally.**",
           "scope": "resource",
           "examples": [


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/20411. We will revert this closer to the 1.37 release.