### PR TITLE
Revert "fix: default "deno.enable" to false temporarily (#913)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
       "properties": {
         "deno.enable": {
           "type": "boolean",
-          "default": false,
+          "default": null,
           "markdownDescription": "Controls if the Deno Language Server is enabled. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services, and will use the Deno Language Server instead.\n\nIf omitted, your preference will be inferred as true if there is a `deno.json[c]` at your workspace root and false if not.\n\nIf you want to enable only part of your workspace folder, consider using `deno.enablePaths` setting instead.\n\n**Not recommended to be enabled globally.**",
           "scope": "resource",
           "examples": [


### PR DESCRIPTION
This reverts commit d299be89ede2002e43413f493c179eb857391399 (#913).

Assuming no more release till the one with 1.37.