### PR TITLE
fix: regression when caching via the command palette

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -184,7 +184,7 @@ function handleConfigurationChange(event: vscode.ConfigurationChangeEvent) {
       event.affectsConfiguration("deno.path") ||
       event.affectsConfiguration("deno.maxTsServerMemory")
     ) {
-      vscode.commands.executeCommand("deno.restart");
+      vscode.commands.executeCommand("deno.client.restart");
     }
   }
 }
@@ -363,35 +363,36 @@ export async function activate(
   // TODO(nayeemrmn): As of Deno 1.37.0, the `deno.cache` command is implemented
   // on the server. Remove this eventually.
   if (!builtinCommands.includes("deno.cache")) {
-    registerCommand("cache", commands.cache);
+    registerCommand("deno.cache", commands.cache);
   }
-  if (!builtinCommands.includes("deno.initializeWorkspace")) {
-    registerCommand("initializeWorkspace", commands.initializeWorkspace);
-  }
-  if (!builtinCommands.includes("deno.restart")) {
-    registerCommand("restart", commands.startLanguageServer);
-  }
-  if (!builtinCommands.includes("deno.reloadImportRegistries")) {
-    registerCommand(
-      "reloadImportRegistries",
-      commands.reloadImportRegistries,
-    );
-  }
+  // TODO(nayeemrmn): Change the LSP's invocations of this to
+  // `deno.client.showReferences`. Remove this one eventually.
   if (!builtinCommands.includes("deno.showReferences")) {
-    registerCommand("showReferences", commands.showReferences);
+    registerCommand("deno.showReferences", commands.showReferences);
   }
-  if (!builtinCommands.includes("deno.status")) {
-    registerCommand("status", commands.status);
-  }
+  registerCommand("deno.client.showReferences", commands.showReferences);
+  // TODO(nayeemrmn): Change the LSP's invocations of this to
+  // `deno.client.test`. Remove this one eventually.
   if (!builtinCommands.includes("deno.test")) {
-    registerCommand("test", commands.test);
+    registerCommand("deno.test", commands.test);
   }
-  if (!builtinCommands.includes("deno.welcome")) {
-    registerCommand("welcome", commands.welcome);
-  }
-  if (!builtinCommands.includes("deno.openOutput")) {
-    registerCommand("openOutput", commands.openOutput);
-  }
+  registerCommand("deno.client.test", commands.test);
+  registerCommand(
+    "deno.client.cacheActiveDocument",
+    commands.cacheActiveDocument,
+  );
+  registerCommand(
+    "deno.client.initializeWorkspace",
+    commands.initializeWorkspace,
+  );
+  registerCommand("deno.client.restart", commands.startLanguageServer);
+  registerCommand(
+    "deno.client.reloadImportRegistries",
+    commands.reloadImportRegistries,
+  );
+  registerCommand("deno.client.status", commands.status);
+  registerCommand("deno.client.welcome", commands.welcome);
+  registerCommand("deno.client.openOutput", commands.openOutput);
 }
 
 export function deactivate(): Thenable<void> | undefined {
@@ -418,10 +419,9 @@ function createRegisterCommand(
       extensionContext: DenoExtensionContext,
     ) => commands.Callback,
   ): void {
-    const fullName = `${EXTENSION_NS}.${name}`;
     const command = factory(context, extensionContext);
     context.subscriptions.push(
-      vscode.commands.registerCommand(fullName, command),
+      vscode.commands.registerCommand(name, command),
     );
   };
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -376,6 +376,11 @@ export async function activate(
   if (!builtinCommands.includes("deno.test")) {
     registerCommand("deno.test", commands.test);
   }
+  // TODO(nayeemrmn): Move server-side as `deno.reloadImportRegistries`.
+  registerCommand(
+    "deno.client.reloadImportRegistries",
+    commands.reloadImportRegistries,
+  );
   registerCommand("deno.client.test", commands.test);
   registerCommand(
     "deno.client.cacheActiveDocument",
@@ -386,10 +391,6 @@ export async function activate(
     commands.initializeWorkspace,
   );
   registerCommand("deno.client.restart", commands.startLanguageServer);
-  registerCommand(
-    "deno.client.reloadImportRegistries",
-    commands.reloadImportRegistries,
-  );
   registerCommand("deno.client.status", commands.status);
   registerCommand("deno.client.welcome", commands.welcome);
   registerCommand("deno.client.openOutput", commands.openOutput);

--- a/client/src/status_bar.ts
+++ b/client/src/status_bar.ts
@@ -12,7 +12,7 @@ export class DenoStatusBar {
       vscode.StatusBarAlignment.Right,
       0,
     );
-    this.#inner.command = "deno.openOutput";
+    this.#inner.command = "deno.client.openOutput";
   }
 
   dispose() {

--- a/client/src/welcome.ts
+++ b/client/src/welcome.ts
@@ -48,7 +48,7 @@ export class WelcomePanel {
             return;
           }
           case "init": {
-            vscode.commands.executeCommand("deno.initializeWorkspace");
+            vscode.commands.executeCommand("deno.client.initializeWorkspace");
             return;
           }
         }
@@ -115,7 +115,7 @@ export class WelcomePanel {
           </ul>
         </div>
       </div>
-      
+
       <div class="Cards">
         <div class="Card">
           <div class="Card-inner">
@@ -149,7 +149,7 @@ export class WelcomePanel {
         </div>
       </div>
       </main>
-      
+
       <script nonce="${nonce}" src="${scriptURI}"></script>
       </body>
       </html>`;

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "onDebugResolve:typescriptreact",
     "onDebugResolve:javascript",
     "onDebugResolve:javascriptreact",
-    "onCommand:deno.welcome",
-    "onCommand:deno.initializeWorkspace",
-    "onCommand:deno.reloadImportRegistries",
+    "onCommand:deno.client.welcome",
+    "onCommand:deno.client.initializeWorkspace",
+    "onCommand:deno.client.reloadImportRegistries",
     "onWebviewPanel:welcomeDeno"
   ],
   "main": "./client/dist/main",
@@ -80,40 +80,40 @@
     ],
     "commands": [
       {
-        "command": "deno.cache",
+        "command": "deno.client.cacheActiveDocument",
         "title": "Cache Dependencies",
         "category": "Deno",
         "description": "Cache the active workspace document and its dependencies.",
         "enablement": "deno:lspReady"
       },
       {
-        "command": "deno.initializeWorkspace",
+        "command": "deno.client.initializeWorkspace",
         "title": "Initialize Workspace Configuration",
         "category": "Deno",
         "description": "Initialize the workspace configuration for Deno."
       },
       {
-        "command": "deno.reloadImportRegistries",
+        "command": "deno.client.reloadImportRegistries",
         "title": "Reload Import Registries Cache",
         "category": "Deno",
         "description": "Reload any cached import registry responses.",
         "enablement": "deno:lspReady"
       },
       {
-        "command": "deno.restart",
+        "command": "deno.client.restart",
         "title": "Restart Language Server",
         "category": "Deno",
         "description": "Restart the Deno language server."
       },
       {
-        "command": "deno.status",
+        "command": "deno.client.status",
         "title": "Language Server Status",
         "category": "Deno",
         "description": "Provide a status document of the language server.",
         "enablement": "deno:lspReady"
       },
       {
-        "command": "deno.welcome",
+        "command": "deno.client.welcome",
         "title": "Welcome",
         "category": "Deno",
         "description": "Open the welcome page for the Deno extension."


### PR DESCRIPTION
When moving the `deno.cache` command server-side (https://github.com/denoland/deno/pull/20111), it stopped working when you run it from the command palette since no args are passed in that case. I was testing it with the code action only. This separates the one intended to be run that way into a separate command: `deno.client.cacheActiveDocument`. There's no sense in implementing these under the same command.

For clarity and future-compat, this renames all of the commands that are supposed to be implemented by the client/editor from `deno.<name>` to `deno.client.<name>`.