### PR TITLE
chore: version check for client-side "deno.cacheOnSave"

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -214,8 +214,13 @@ function handleDocumentOpen(...documents: vscode.TextDocument[]) {
   }
 }
 
+// TODO(nayeemrmn): Deno LSP versions > 1.37.0 handle `cacheOnSave`
+// server-side. Eventually remove this handler.
 function handleTextDocumentSave(doc: vscode.TextDocument) {
   if (!LANGUAGES.includes(doc.languageId)) {
+    return;
+  }
+  if (semver.gt(extensionContext.serverInfo?.version ?? "1.0.0", "1.37.0")) {
     return;
   }
   if (extensionContext.workspaceSettings.cacheOnSave) {

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -143,7 +143,6 @@ class Plugin implements ts.server.PluginModule {
       // deno-lint-ignore no-explicit-any
       const target = (ls as any)[fn];
       return (...args) => {
-        this.#log(fn, args);
         const enabled = fileNameArg !== undefined
           ? this.#fileNameDenoEnabled(args[fileNameArg] as string)
           : this.#denoEnabled();

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -143,6 +143,7 @@ class Plugin implements ts.server.PluginModule {
       // deno-lint-ignore no-explicit-any
       const target = (ls as any)[fn];
       return (...args) => {
+        this.#log(fn, args);
         const enabled = fileNameArg !== undefined
           ? this.#fileNameDenoEnabled(args[fileNameArg] as string)
           : this.#denoEnabled();


### PR DESCRIPTION
https://github.com/denoland/deno/pull/20632 moves `deno.cacheOnSave` handling to the server-side, available as of `1.37.0+33f8432`. Disables the implementation here for LSP versions > 1.37.0 (this leaves a dead-zone where you won't have either for some stale canary versions, but that's okay and we want to ship this to proper nightly users).