### PR TITLE
feat: register notebook cells with the language client

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -256,6 +256,7 @@ export async function activate(
 ): Promise<void> {
   extensionContext.outputChannel = extensionContext.outputChannel ??
     vscode.window.createOutputChannel(LANGUAGE_CLIENT_NAME);
+  const p2cMap = new Map<string, string>();
   extensionContext.clientOptions = {
     documentSelector: [
       { scheme: "file", language: "javascript" },
@@ -269,7 +270,30 @@ export async function activate(
       { scheme: "file", language: "json" },
       { scheme: "file", language: "jsonc" },
       { scheme: "file", language: "markdown" },
+      { notebook: "*", language: "javascript" },
+      { notebook: "*", language: "javascriptreact" },
+      { notebook: "*", language: "typescript" },
+      { notebook: "*", language: "typescriptreact" },
     ],
+    uriConverters: {
+      code2Protocol: (uri) => {
+        if (uri.scheme == "vscode-notebook-cell") {
+          const string = uri.with({
+            scheme: "deno-file-fragment",
+          }).toString();
+          p2cMap.set(string, uri.toString());
+          return string;
+        }
+        return uri.toString();
+      },
+      protocol2Code: (s) => {
+        const maybeMapped = p2cMap.get(s);
+        if (maybeMapped) {
+          return vscode.Uri.parse(maybeMapped);
+        }
+        return vscode.Uri.parse(s);
+      },
+    },
     diagnosticCollectionName: "deno",
     initializationOptions: () => {
       const options: Settings & { enableBuiltinCommands?: true } =

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -279,7 +279,7 @@ export async function activate(
       code2Protocol: (uri) => {
         if (uri.scheme == "vscode-notebook-cell") {
           const string = uri.with({
-            scheme: "deno-file-fragment",
+            scheme: "deno-notebook-cell",
           }).toString();
           p2cMap.set(string, uri.toString());
           return string;

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -143,6 +143,7 @@ class Plugin implements ts.server.PluginModule {
       // deno-lint-ignore no-explicit-any
       const target = (ls as any)[fn];
       return (...args) => {
+        this.#log(fn, args);
         const enabled = fileNameArg !== undefined
           ? this.#fileNameDenoEnabled(args[fileNameArg] as string)
           : this.#denoEnabled();


### PR DESCRIPTION
Start sending notebook cells to the LSP.

VSCode stores these cells as documents with URLs like:
```
vscode-notebook-cell:/home/nayeem/projects/vscode_deno/notebook.ipynb#W0aIKpasdpH53D%3D
```
When sending them to the LSP, I've mapped them to:
```
deno-file-fragment:/home/nayeem/projects/vscode_deno/notebook.ipynb#W0aIKpasdpH53D%3D
```
because it's neutral to other editors and because the handling in the LSP is pretty generic wrt 'file fragments'. Neither `file:///` (actual FS files with no fragment) nor `deno:` (static virtual documents with paths not related to the actual FS) are appropriate for this.