### PR TITLE
feat(fresh): add fresh route view, snippets

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -19,6 +19,7 @@ import { getTsApi } from "./ts_api";
 import type { DenoExtensionContext, Settings } from "./types";
 import { assert } from "./util";
 import * as util from "util";
+import * as freshExtension from "./fresh/extension";
 
 import * as vscode from "vscode";
 
@@ -423,6 +424,8 @@ export async function activate(
   registerCommand("deno.client.status", commands.status);
   registerCommand("deno.client.welcome", commands.welcome);
   registerCommand("deno.client.openOutput", commands.openOutput);
+
+  freshExtension.activate(context);
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/client/src/fresh/extension.ts
+++ b/client/src/fresh/extension.ts
@@ -14,7 +14,6 @@ import { FreshRouteViewProvider } from "./webview";
 const getRootPath = () => vscode.workspace?.workspaceFolders?.[0]?.uri?.fsPath;
 
 async function isFreshProject() {
-  console.log("isFreshProject", getRootPath());
   const workspace = getRootPath();
   if (!workspace) {
     return false;
@@ -23,7 +22,7 @@ async function isFreshProject() {
     workspace,
     "fresh.gen.ts",
   );
-  return vscode.workspace.fs.stat(vscode.Uri.file(freshGenPath));
+  return await vscode.workspace.fs.stat(vscode.Uri.file(freshGenPath));
 }
 export function activate(context: vscode.ExtensionContext) {
   isFreshProject().then((isFresh) => {
@@ -58,10 +57,10 @@ export function activate(context: vscode.ExtensionContext) {
     "typescriptreact",
     {
       provideCompletionItems(
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        token: vscode.CancellationToken,
-        context: vscode.CompletionContext,
+        _document: vscode.TextDocument,
+        _position: vscode.Position,
+        _token: vscode.CancellationToken,
+        _context: vscode.CompletionContext,
       ) {
         return [
           snippets.simpleRoute,

--- a/client/src/fresh/extension.ts
+++ b/client/src/fresh/extension.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
 import * as vscode from "vscode";
 import * as snippets from "./snippets";
 import { join } from "path";

--- a/client/src/fresh/extension.ts
+++ b/client/src/fresh/extension.ts
@@ -1,0 +1,84 @@
+import * as vscode from "vscode";
+import * as snippets from "./snippets";
+import { join } from "path";
+import {
+  generateComponent,
+  generateIsland,
+  generateLayout,
+  generateRoute,
+} from "./generate";
+import { FreshRouteViewProvider } from "./webview";
+
+const getRootPath = () => vscode.workspace?.workspaceFolders?.[0]?.uri?.fsPath;
+
+async function isFreshProject() {
+  console.log("isFreshProject", getRootPath());
+  const workspace = getRootPath();
+  if (!workspace) {
+    return false;
+  }
+  const freshGenPath = join(
+    workspace,
+    "fresh.gen.ts",
+  );
+  return vscode.workspace.fs.stat(vscode.Uri.file(freshGenPath));
+}
+export function activate(context: vscode.ExtensionContext) {
+  isFreshProject().then((isFresh) => {
+    vscode.commands.executeCommand(
+      "setContext",
+      "is-fresh-project",
+      isFresh,
+    );
+  });
+  
+  context.subscriptions.push(vscode.commands.registerCommand(
+    "deno.fresh.generateRoute",
+    generateRoute,
+  ));
+
+  context.subscriptions.push(vscode.commands.registerCommand(
+    "deno.fresh.generateLayout",
+    generateLayout,
+  ));
+
+  context.subscriptions.push(vscode.commands.registerCommand(
+    "deno.fresh.generateComponent",
+    generateComponent,
+  ));
+
+  context.subscriptions.push(vscode.commands.registerCommand(
+    "deno.fresh.generateIsland",
+    generateIsland,
+  ));
+
+  const provider = vscode.languages.registerCompletionItemProvider(
+    "typescriptreact",
+    {
+      provideCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken,
+        context: vscode.CompletionContext,
+      ) {
+        return [
+          snippets.simpleRoute,
+          snippets.customHandlers,
+          snippets.layout,
+          snippets.defineRoute,
+          snippets.defineLayout,
+        ];
+      },
+    },
+  );
+
+  context.subscriptions.push(provider);
+
+  const webviewProvider = new FreshRouteViewProvider(context.extensionUri);
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(
+      "deno.fresh.routeView",
+      webviewProvider,
+    ),
+  );
+}

--- a/client/src/fresh/generate.ts
+++ b/client/src/fresh/generate.ts
@@ -9,7 +9,7 @@ async function writeFile(newFile: string, body: string) {
     fileExists = await vscode.workspace.fs.stat(
       vscode.Uri.file(newFile),
     );
-  } catch (error) {
+  } catch (_error) {
     // do nothing
   }
   if (fileExists) {

--- a/client/src/fresh/generate.ts
+++ b/client/src/fresh/generate.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
 import * as vscode from "vscode";
 
 async function writeFile(newFile: string, body: string) {

--- a/client/src/fresh/generate.ts
+++ b/client/src/fresh/generate.ts
@@ -1,0 +1,295 @@
+import * as vscode from "vscode";
+
+async function writeFile(newFile: string, body: string) {
+  // check if file exists
+  let fileExists;
+  try {
+    fileExists = await vscode.workspace.fs.stat(
+      vscode.Uri.file(newFile),
+    );
+  } catch (error) {
+    // do nothing
+  }
+  if (fileExists) {
+    vscode.window.showErrorMessage("File already exists");
+    throw new Error("File already exists");
+  }
+
+  vscode.workspace.fs.writeFile(
+    vscode.Uri.file(newFile),
+    new Uint8Array(Buffer.from(body)),
+  );
+
+  vscode.window.showInformationMessage("File Created");
+}
+
+function kebabToCamelCase(str: string) {
+  return str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+}
+
+function snakeToCamelCase(str: string) {
+  return str.replace(/_([a-z])/g, (g) => g[1].toUpperCase());
+}
+
+function capitalizeFirstLetter(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function camelizeWhatever(str: string) {
+  return capitalizeFirstLetter(snakeToCamelCase(kebabToCamelCase(str)));
+}
+
+interface Route {
+  label: string;
+  body: string;
+}
+
+const routes: Route[] = [
+  {
+    label: "Simple JSX Page",
+    body:
+      `// Document https://fresh.deno.dev/docs/getting-started/create-a-route
+
+export default function __FILENAME__() {
+  return (
+    <main>
+      <h1>__FILENAME__</h1>
+      <p>This is the about page.</p>
+    </main>
+  );
+}`,
+  },
+  {
+    label: "Dynamic route",
+    body:
+      `// Document https://fresh.deno.dev/docs/getting-started/dynamic-routes
+
+import { PageProps } from "$fresh/server.ts";
+
+export default function __FILENAME__(props: PageProps) {
+  const { name } = props.params;
+  return (
+    <main>
+      <p>Greetings to you, {name}!</p>
+    </main>
+  );
+}`,
+  },
+  {
+    label: "Handler route",
+    body: `// Document https://fresh.deno.dev/docs/concepts/routes#handler-route
+
+import { HandlerContext, Handlers } from "$fresh/server.ts";
+
+export const handler: Handlers = {
+  GET(_req: Request, _ctx: HandlerContext) {
+    return new Response("Hello World");
+  },
+};`,
+  },
+];
+
+const asyncRoutes: Route[] = [
+  {
+    label: "Async component route with defineHelper (Recommended)",
+    body: `// Document https://fresh.deno.dev/docs/concepts/routes#define-helper
+
+import { defineRoute } from "$fresh/server.ts";
+
+export default defineRoute(async (req, ctx) => {
+  // const data = await loadData();
+  const data = { name: "World" };
+
+  return (
+    <div class="page">
+      <h1>Hello {data.name}</h1>
+    </div>
+  );
+});`,
+  },
+  {
+    label: "Mixed handler and component route",
+    body:
+      `// Document https://fresh.deno.dev/docs/concepts/routes#mixed-handler-and-component-route
+
+import { Handlers, PageProps } from "$fresh/server.ts";
+
+interface Data {
+  foo: number;
+}
+
+export const handler: Handlers<Data> = {
+  async GET(_req, ctx) {
+    // const value = await loadFooValue();
+    return ctx.render({ foo: 1 });
+  },
+};
+
+export default function __FILENAME__(props: PageProps<Data>) {
+  return <p>foo is: {props.data.foo}</p>;
+}`,
+  },
+  {
+    label: "Async component route",
+    body: `// Document https://fresh.deno.dev/docs/concepts/routes#handler-route
+
+import { RouteContext } from "$fresh/server.ts";
+  
+  export default async function __FILENAME__(req: Request, ctx: RouteContext) {
+  // const value = await loadFooValue();
+  return <p>foo is: {1}</p>;
+}`,
+  },
+];
+
+function addTsxExtensionIfMissing(fileName: string) {
+  if (fileName.endsWith(".tsx")) {
+    return fileName;
+  }
+  return fileName + ".tsx";
+}
+
+export async function generateRoute(uri: vscode.Uri) {
+  if (!uri) {
+    vscode.window.showErrorMessage(
+      "Please left click on a folder in the explorer and try again from context menu",
+    );
+    return;
+  }
+
+  const fileName = await vscode.window.showInputBox({
+    prompt: "Enter file name",
+    placeHolder: "index.tsx",
+    value: "index.tsx",
+  });
+  if (!fileName) {
+    return;
+  }
+
+  const newFile = uri.fsPath + "/" + addTsxExtensionIfMissing(fileName);
+  const optAsync = await vscode.window.showQuickPick([
+    "No",
+    "Yes",
+  ], {
+    placeHolder: "Do you need async route? (example: data fetching)",
+  });
+  if (!optAsync) {
+    return;
+  }
+
+  let body = "";
+
+  if (optAsync === "Yes") {
+    body = (await vscode.window.showQuickPick(asyncRoutes, {
+      placeHolder: "Select a snippet",
+    }))?.body ?? "";
+  } else {
+    body = (await vscode.window.showQuickPick(routes, {
+      placeHolder: "Select a snippet",
+    }))?.body ?? "";
+  }
+  if (!body) {
+    return;
+  }
+
+  body = body.replace(
+    /__FILENAME__/g,
+    camelizeWhatever(fileName.replace(".tsx", "")),
+  );
+
+  try {
+    await writeFile(newFile, body);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      vscode.window.showErrorMessage(error.message);
+    }
+  }
+}
+
+async function generateFile(
+  uri: vscode.Uri,
+  body: string,
+  defaultFileName = "index.tsx",
+) {
+  if (!uri) {
+    vscode.window.showErrorMessage(
+      "Please left click on a folder in the explorer and try again from context menu",
+    );
+    return;
+  }
+
+  const fileName = await vscode.window.showInputBox({
+    prompt: "Enter file name",
+    placeHolder: defaultFileName,
+    value: defaultFileName,
+  });
+
+  if (!fileName) {
+    return;
+  }
+
+  const newFile = uri.fsPath + "/" + addTsxExtensionIfMissing(fileName);
+
+  const nameForClass = camelizeWhatever(fileName.split(".")[0]);
+  body = body.replace(/__FILENAME__/g, nameForClass);
+
+  try {
+    await writeFile(newFile, body);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      vscode.window.showErrorMessage(error.message);
+    }
+  }
+}
+
+export async function generateLayout(uri: vscode.Uri) {
+  const body = `// Document https://fresh.deno.dev/docs/concepts/layouts
+
+import { LayoutProps } from "$fresh/server.ts";
+
+export default function Layout({ Component, state }: LayoutProps) {
+  return (
+    <div class="layout">
+      <Component />
+    </div>
+  );
+}`;
+
+  await generateFile(uri, body, "_layout.tsx");
+}
+
+export async function generateComponent(uri: vscode.Uri) {
+  const body = `import { JSX } from "preact";
+
+export function __FILENAME__(props: JSX.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div {...props}>
+      <h1>__FILENAME__</h1>
+    </div>
+  );
+}`;
+
+  await generateFile(uri, body);
+}
+
+export async function generateIsland(uri: vscode.Uri) {
+  const body = `// Document https://fresh.deno.dev/docs/concepts/islands
+
+import type { Signal } from "@preact/signals";
+
+interface __FILENAME__Props {
+  count: Signal<number>;
+}
+
+export default function __FILENAME__(props: __FILENAME__Props) {
+  return (
+    <div>
+      <button onClick={() => props.count.value -= 1}>-1</button>
+      <p>{props.count}</p>
+      <button onClick={() => props.count.value += 1}>+1</button>
+    </div>
+  );
+}`;
+
+  await generateFile(uri, body);
+}

--- a/client/src/fresh/getRoutes.ts
+++ b/client/src/fresh/getRoutes.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
 import * as vscode from "vscode";
 import * as fs from "fs";
 import { extname } from "path";

--- a/client/src/fresh/getRoutes.ts
+++ b/client/src/fresh/getRoutes.ts
@@ -1,0 +1,151 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import { extname } from "path";
+
+// from Fresh source
+// https://github.com/denoland/fresh/blob/main/src/server/context.ts#L1131
+/** Transform a filesystem URL path to a `path-to-regex` style matcher. */
+function pathToPattern(path: string) {
+  const parts = path.split("/");
+  if (parts[parts.length - 1] === "index") {
+    if (parts.length === 1) {
+      return "/";
+    }
+    parts.pop();
+  }
+
+  let route = "";
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+
+    // Case: /[...foo].tsx
+    if (part.startsWith("[...") && part.endsWith("]")) {
+      route += `/:${part.slice(4, part.length - 1)}*`;
+      continue;
+    }
+
+    // Route groups like /foo/(bar) should not be included in URL
+    // matching. They are transparent and need to be removed here.
+    // Case: /foo/(bar) -> /foo
+    // Case: /foo/(bar)/bob -> /foo/bob
+    // Case: /(foo)/bar -> /bar
+    if (part.startsWith("(") && part.endsWith(")")) {
+      continue;
+    }
+
+    // Disallow neighbouring params like `/[id][bar].tsx` because
+    // it's ambiguous where the `id` param ends and `bar` begins.
+    if (part.includes("][")) {
+      throw new SyntaxError(
+        `Invalid route pattern: "${path}". A parameter cannot be followed by another parameter without any characters in between.`,
+      );
+    }
+
+    // Case: /[[id]].tsx
+    // Case: /[id].tsx
+    // Case: /[id]@[bar].tsx
+    // Case: /[id]-asdf.tsx
+    // Case: /[id]-asdf[bar].tsx
+    // Case: /asdf[bar].tsx
+    let pattern = "";
+    let groupOpen = 0;
+    let optional = false;
+    for (let j = 0; j < part.length; j++) {
+      const char = part[j];
+      if (char === "[") {
+        if (part[j + 1] === "[") {
+          // Disallow optional dynamic params like `foo-[[bar]]`
+          if (part[j - 1] !== "/" && !!part[j - 1]) {
+            throw new SyntaxError(
+              `Invalid route pattern: "${path}". An optional parameter needs to be a full segment.`,
+            );
+          }
+          groupOpen++;
+          optional = true;
+          pattern += "{/";
+          j++;
+        }
+        pattern += ":";
+        groupOpen++;
+      } else if (char === "]") {
+        if (part[j + 1] === "]") {
+          // Disallow optional dynamic params like `[[foo]]-bar`
+          if (part[j + 2] !== "/" && !!part[j + 2]) {
+            throw new SyntaxError(
+              `Invalid route pattern: "${path}". An optional parameter needs to be a full segment.`,
+            );
+          }
+          groupOpen--;
+          pattern += "}?";
+          j++;
+        }
+        if (--groupOpen < 0) {
+          throw new SyntaxError(`Invalid route pattern: "${path}"`);
+        }
+      } else {
+        pattern += char;
+      }
+    }
+
+    route += (optional ? "" : "/") + pattern;
+  }
+
+  // Case: /(group)/index.tsx
+  if (route === "") {
+    route = "/";
+  }
+
+  return route;
+}
+
+interface Routes {
+  route: string;
+  file: string;
+}
+
+interface RouteWithPattern extends Routes {
+  pattern: string;
+}
+
+export async function getAllRoutes() {
+  const currentProject = vscode.workspace.workspaceFolders?.[0];
+  const projectPath = currentProject?.uri.fsPath;
+
+  if (!projectPath) {
+    return [];
+  }
+
+  const filename = `${projectPath}/fresh.gen.ts`;
+
+  const input = await fs.promises.readFile(filename, "utf8");
+
+  const routes: Routes[] = input.split("\n").filter((line: string) =>
+    line.includes("./routes") && !line.includes("import")
+  ).map((
+    line: string,
+  ) =>
+    line.split(":")[0].trim().replace(/"/g, "").replace(/^\.\//g, "").replace(
+      /^routes\//,
+      "",
+    )
+  ).map(
+    (item) => {
+      return {
+        file: item,
+        route: item.substring(0, item.length - extname(item).length),
+      };
+    },
+  );
+
+  const patterns: RouteWithPattern[] = routes.map((route) => {
+    const pattern = pathToPattern(route.route);
+    return {
+      route: route.route,
+      file: route.file,
+      pattern,
+    };
+  });
+
+  return patterns;
+}

--- a/client/src/fresh/snippets.ts
+++ b/client/src/fresh/snippets.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
 import * as vscode from "vscode";
 
 export const simpleRoute = new vscode.CompletionItem("Fresh - Simple Route");

--- a/client/src/fresh/snippets.ts
+++ b/client/src/fresh/snippets.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+
+export const simpleRoute = new vscode.CompletionItem("Fresh - Simple Route");
+simpleRoute.insertText = new vscode.SnippetString(
+  [
+    "export default function ${1:Page}(props: PageProps) {",
+    "	return (",
+    "		<main>",
+    "			<h1>About</h1>",
+    "			<p>This is the about page.</p>",
+    "		</main>",
+    "	);",
+    "});",
+  ].join("\n"),
+);
+
+export const customHandlers = new vscode.CompletionItem(
+  "Fresh - Custom Handlers",
+);
+customHandlers.insertText = new vscode.SnippetString([
+  "export const handler: Handlers = {",
+  "	async GET(_req, ctx) {",
+  "    return await ctx.render();",
+  "  },",
+  "};",
+].join("\n"));
+
+export const layout = new vscode.CompletionItem(
+  "Fresh - Layouts",
+);
+
+layout.insertText = new vscode.SnippetString([
+  "export default function Layout({ Component, state }: LayoutProps) {",
+  "	// do something with state here",
+  "	return (",
+  '		<div class="layout">',
+  "			<Component />",
+  "		</div>",
+  "	);",
+  "}",
+].join("\n"));
+
+export const defineRoute = new vscode.CompletionItem(
+  "Fresh - Define Route",
+);
+defineRoute.insertText = new vscode.SnippetString([
+  "export default defineRoute(async (req, ctx) => {",
+  "	return (",
+  "		<div></div>",
+  "	);",
+  "});",
+].join("\n"));
+
+export const defineLayout = new vscode.CompletionItem(
+  "Fresh - Define Layout",
+);
+defineLayout.insertText = new vscode.SnippetString([
+  "export default defineLayout(async (req, ctx) => {",
+  "	return (",
+  "		<div>",
+  "			<ctx.Component />",
+  "		</div>",
+  "	);",
+  "});",
+].join("\n"));

--- a/client/src/fresh/webview.ts
+++ b/client/src/fresh/webview.ts
@@ -88,7 +88,7 @@ export class FreshRouteViewProvider implements vscode.WebviewViewProvider {
       ),
     );
 
-    const nonce = "Hogehoge";
+    const nonce = getNonce();
 
     return `<!DOCTYPE html>
 			<html lang="en">
@@ -137,4 +137,14 @@ export class FreshRouteViewProvider implements vscode.WebviewViewProvider {
 			</body>
 			</html>`;
   }
+}
+
+function getNonce() {
+  let text = "";
+  const possible =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
 }

--- a/client/src/fresh/webview.ts
+++ b/client/src/fresh/webview.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
 import * as vscode from "vscode";
 import { getAllRoutes } from "./getRoutes";
 

--- a/client/src/fresh/webview.ts
+++ b/client/src/fresh/webview.ts
@@ -10,8 +10,8 @@ export class FreshRouteViewProvider implements vscode.WebviewViewProvider {
   ) {}
   resolveWebviewView(
     webviewView: vscode.WebviewView,
-    context: vscode.WebviewViewResolveContext<unknown>,
-    token: vscode.CancellationToken,
+    _context: vscode.WebviewViewResolveContext<unknown>,
+    _token: vscode.CancellationToken,
   ): void | Thenable<void> {
     this._view = webviewView;
 

--- a/client/src/fresh/webview.ts
+++ b/client/src/fresh/webview.ts
@@ -1,0 +1,138 @@
+import * as vscode from "vscode";
+import { getAllRoutes } from "./getRoutes";
+
+export class FreshRouteViewProvider implements vscode.WebviewViewProvider {
+  private _view?: vscode.WebviewView;
+  constructor(
+    private readonly _extensionUri: vscode.Uri,
+  ) {}
+  resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    context: vscode.WebviewViewResolveContext<unknown>,
+    token: vscode.CancellationToken,
+  ): void | Thenable<void> {
+    this._view = webviewView;
+
+    webviewView.webview.options = {
+      enableScripts: true,
+
+      localResourceRoots: [
+        this._extensionUri,
+      ],
+    };
+
+    webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+
+    webviewView.webview.onDidReceiveMessage(async (data) => {
+      switch (data.type) {
+        case "colorSelected": {
+          vscode.window.activeTextEditor?.insertSnippet(
+            new vscode.SnippetString(`#${data.value}`),
+          );
+          break;
+        }
+        case "update": {
+          const routes = await getAllRoutes();
+          webviewView.webview.postMessage({
+            type: "setRoutes",
+            value: routes,
+          });
+          break;
+        }
+        case "open": {
+          // open in editor
+          const projectPath = vscode.workspace.workspaceFolders?.[0].uri;
+          if (!projectPath) {
+            return;
+          }
+          const uri = vscode.Uri.joinPath(projectPath, "routes", data.value);
+
+          const doc = await vscode.workspace.openTextDocument(uri);
+          await vscode.window.showTextDocument(doc);
+
+          break;
+        }
+      }
+    });
+  }
+
+  private _getHtmlForWebview(webview: vscode.Webview) {
+    // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
+    const freshSubFolder = "fresh";
+    const scriptUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        "media",
+        freshSubFolder,
+        "main.js",
+      ),
+    );
+
+    // Do the same for the stylesheet.
+    const styleVSCodeUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        "media",
+        freshSubFolder,
+        "vscode.css",
+      ),
+    );
+    const styleMainUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        "media",
+        freshSubFolder,
+        "main.css",
+      ),
+    );
+
+    const nonce = "Hogehoge";
+
+    return `<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+
+				<!--
+					Use a content security policy to only allow loading styles from our extension directory,
+					and only allow scripts that have a specific nonce.
+					(See the 'webview-sample' extension sample for img-src content security policy examples)
+				-->
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+				<link href="${styleVSCodeUri}" rel="stylesheet">
+				<link href="${styleMainUri}" rel="stylesheet">
+
+				<title>Fresh URL Matcher</title>
+			</head>
+			<body>
+        <svg viewBox="0 0 24 25" fill="none" display="none" xmlns="http://www.w3.org/2000/svg">
+          <symbol id="icon-path">
+            <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" d="M12 2.5C10.284 2.5 8.904 3.88 6.142 6.642C3.381 9.404 2 10.784 2 12.5C2 14.216 3.38 15.596 6.142 18.358C8.904 21.119 10.284 22.5 12 22.5C13.716 22.5 15.096 21.12 17.858 18.358C20.619 15.596 22 14.216 22 12.5C22 10.784 20.62 9.404 17.858 6.642C15.096 3.881 13.716 2.5 12 2.5Z" fill="#61FF97"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M12.786 8.98701C12.9221 8.84195 13.1102 8.75688 13.309 8.75051C13.5077 8.74413 13.7009 8.81697 13.846 8.95301L16.513 11.453C16.5878 11.5232 16.6474 11.6079 16.6881 11.702C16.7289 11.796 16.7499 11.8975 16.7499 12C16.7499 12.1025 16.7289 12.204 16.6881 12.2981C16.6474 12.3921 16.5878 12.4769 16.513 12.547L13.846 15.047C13.7003 15.1796 13.5083 15.2496 13.3115 15.2419C13.1146 15.2341 12.9288 15.1492 12.794 15.0055C12.6592 14.8618 12.5864 14.6709 12.5913 14.4739C12.5962 14.277 12.6783 14.0899 12.82 13.953L14.103 12.75H10.667C10.333 12.75 9.822 12.85 9.42 13.122C9.057 13.367 8.75 13.765 8.75 14.5C8.75 14.6989 8.67098 14.8897 8.53033 15.0303C8.38968 15.171 8.19891 15.25 8 15.25C7.80109 15.25 7.61032 15.171 7.46967 15.0303C7.32902 14.8897 7.25 14.6989 7.25 14.5C7.25 13.235 7.832 12.383 8.58 11.878C9.289 11.4 10.112 11.25 10.667 11.25H14.103L12.82 10.047C12.6749 9.91094 12.5899 9.72283 12.5835 9.52405C12.5771 9.32527 12.65 9.13209 12.786 8.98701Z" fill="#61FF97"/>
+          </symbol>
+          <symbol id="icon-special">
+            <path opacity="0.5" d="M2 12.5C2 7.786 2 5.429 3.464 3.964C4.93 2.5 7.286 2.5 12 2.5C16.714 2.5 19.071 2.5 20.535 3.964C22 5.43 22 7.786 22 12.5C22 17.214 22 19.571 20.535 21.035C19.072 22.5 16.714 22.5 12 22.5C7.286 22.5 4.929 22.5 3.464 21.035C2 19.572 2 17.214 2 12.5Z" fill="#B76FFF"/>
+            <path d="M13.488 6.94601C13.68 6.99757 13.8436 7.12322 13.943 7.29534C14.0423 7.46747 14.0693 7.672 14.018 7.86401L11.43 17.524C11.4045 17.6192 11.3604 17.7083 11.3004 17.7865C11.2404 17.8646 11.1656 17.9301 11.0803 17.9793C10.9079 18.0787 10.7032 18.1056 10.511 18.054C10.3189 18.0024 10.1551 17.8766 10.0557 17.7043C9.95628 17.5319 9.92943 17.3272 9.98101 17.135L12.569 7.47601C12.5945 7.38075 12.6386 7.29146 12.6987 7.21324C12.7587 7.13503 12.8336 7.06943 12.9191 7.0202C13.0045 6.97097 13.0989 6.93908 13.1967 6.92635C13.2945 6.91362 13.3938 6.9203 13.489 6.94601H13.488ZM14.97 8.97001C15.1106 8.82956 15.3013 8.75067 15.5 8.75067C15.6988 8.75067 15.8894 8.82956 16.03 8.97001L16.239 9.17801C16.874 9.81301 17.404 10.343 17.768 10.82C18.152 11.324 18.422 11.856 18.422 12.5C18.422 13.144 18.152 13.676 17.768 14.18C17.404 14.657 16.874 15.187 16.238 15.822L16.03 16.03C15.9613 16.1037 15.8785 16.1628 15.7865 16.2038C15.6945 16.2448 15.5952 16.2668 15.4945 16.2686C15.3938 16.2704 15.2938 16.2519 15.2004 16.2141C15.107 16.1764 15.0222 16.1203 14.951 16.0491C14.8798 15.9778 14.8236 15.893 14.7859 15.7996C14.7482 15.7062 14.7296 15.6062 14.7314 15.5055C14.7332 15.4048 14.7552 15.3055 14.7962 15.2135C14.8372 15.1215 14.8963 15.0387 14.97 14.97L15.141 14.798C15.823 14.116 16.28 13.658 16.575 13.27C16.858 12.9 16.922 12.684 16.922 12.5C16.922 12.316 16.858 12.1 16.575 11.73C16.28 11.343 15.823 10.884 15.141 10.202L14.97 10.03C14.8296 9.88939 14.7507 9.69876 14.7507 9.50001C14.7507 9.30126 14.8296 9.11064 14.97 8.97001ZM7.97001 8.97001C8.11218 8.83753 8.30023 8.76541 8.49453 8.76884C8.68883 8.77227 8.87422 8.85098 9.01163 8.98839C9.14904 9.12581 9.22776 9.31119 9.23119 9.50549C9.23461 9.69979 9.16249 9.88784 9.03001 10.03L8.85901 10.202C8.17701 10.884 7.72101 11.342 7.42501 11.73C7.14201 12.1 7.07901 12.316 7.07901 12.5C7.07901 12.684 7.14201 12.9 7.42501 13.27C7.72101 13.657 8.17701 14.116 8.85901 14.798L9.03101 14.97C9.10261 15.0392 9.15971 15.122 9.19897 15.2135C9.23823 15.3051 9.25887 15.4035 9.25969 15.5031C9.26051 15.6027 9.24149 15.7014 9.20373 15.7936C9.16598 15.8857 9.11025 15.9694 9.0398 16.0398C8.96935 16.1102 8.88558 16.1658 8.79339 16.2035C8.7012 16.2412 8.60243 16.2601 8.50285 16.2592C8.40327 16.2583 8.30486 16.2376 8.21338 16.1982C8.12189 16.1589 8.03916 16.1017 7.97001 16.03L7.76201 15.822C7.12601 15.187 6.59601 14.657 6.23201 14.18C5.84801 13.676 5.57901 13.144 5.57901 12.5C5.57901 11.856 5.84901 11.324 6.23201 10.82C6.59601 10.343 7.12601 9.81301 7.76201 9.17801L7.97001 8.97001Z" fill="#B76FFF"/>
+          </symbol>
+        </svg>
+
+        <svg width="20" height="21" viewBox="0 0 20 21" fill="none" display="none" xmlns="http://www.w3.org/2000/svg">
+          <symbol id="icon-external">
+            <path d="M13.0333 6.35417H10.015V4.6875H15.8483V10.5208H14.1817V7.5625L10.0867 11.6575L8.90833 10.4792L13.0333 6.35417Z" fill="currentColor"/>
+            <path d="M9.15167 6.3125H4.15167V16.3125H14.1517V11.3125H12.485V14.6458H5.81834V7.97917H9.15167V6.3125Z" fill="currentColor"/>
+          </symbol>
+        </svg>
+
+        <input type="text" id="UrlMatcher" class="path-input" placeholder="Test a URL (Example: /books/123 )">
+
+        <ul class="route-list">
+				</ul>
+
+				<script nonce="${nonce}" src="${scriptUri}"></script>
+			</body>
+			</html>`;
+  }
+}

--- a/media/fresh/main.css
+++ b/media/fresh/main.css
@@ -1,3 +1,5 @@
+/* Copyright 2018-2022 the Deno authors. All rights reserved. MIT license. */
+
 body {
   background-color: transparent;
 }

--- a/media/fresh/main.css
+++ b/media/fresh/main.css
@@ -1,0 +1,109 @@
+body {
+  background-color: transparent;
+}
+
+.path-input {
+  display: block;
+  flex: 1;
+  width: 100%;
+  color: var(--vscode-input-foreground);
+  background-color: var(--vscode-input-background);
+  border: none;
+  padding: 0 0.6em;
+}
+
+.route-list {
+  list-style: none;
+  padding: 0;
+}
+
+.route-entry {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  padding: 0.2em 0.4em;
+}
+
+.route-entry:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.route-entry.selected {
+  background-color: var(--vscode-list-activeSelectionBackground);
+}
+.route-entry a {
+  text-decoration: none;
+}
+
+.route-entry a:hover {
+  text-decoration: underline;
+}
+
+.route-entry.selected > a {
+  background-color: var(--vscode-list-activeSelectionBackground);
+}
+
+.route-name {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex: 1;
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  justify-content: flex-start;
+}
+
+.route-label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex: 1;
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  justify-content: flex-start;
+  color: var(--vscode-descriptionForeground);
+}
+.route-label input {
+  width: 40px;
+  color: var(--vscode-input-foreground);
+  background-color: var(--vscode-input-background);
+  border: var(--vscode-input-border);
+  padding: 0.1em 0.2em;
+}
+
+.icon {
+  flex: none;
+  display: block;
+  margin-right: 0.2em;
+}
+.icon-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-link svg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.route-action {
+  display: flex;
+  justify-content: flex-end;
+  gap: 2px;
+}
+input.route-param {
+  color: rgb(193, 255, 207);
+}
+@media screen and (min-width: 280px) {
+  .route-entry {
+    flex-direction: row;
+    align-items: center;
+  }
+  .route-action {
+    justify-content: center;
+  }
+}

--- a/media/fresh/main.js
+++ b/media/fresh/main.js
@@ -1,0 +1,352 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+//@ts-check
+
+// This script will be run within the webview itself
+// It cannot access the main VS Code APIs directly.
+(function () {
+  // @ts-ignore
+  const vscode = acquireVsCodeApi();
+
+  const oldRoutes = [];
+
+  let urlFilter = "";
+
+  let selectedRoute = null;
+
+  // Handle messages sent from the extension to the webview
+  window.addEventListener("message", (event) => {
+    const message = event.data; // The json data that the extension sent
+    switch (message.type) {
+      case "setRoutes": {
+        const routes = message.value;
+        if (JSON.stringify(routes) === JSON.stringify(oldRoutes)) {
+          return;
+        }
+        updateRoutes(routes, urlFilter);
+        oldRoutes.length = 0;
+        oldRoutes.push(...routes);
+        break;
+      }
+    }
+  });
+
+  const urlMatcher = document.getElementById("UrlMatcher");
+  if (!urlMatcher) {
+    return;
+  }
+  urlMatcher.addEventListener("input", (e) => {
+    const input = e.target;
+    if (!(input instanceof HTMLInputElement)) {
+      return;
+    }
+    urlFilter = input.value;
+    updateRoutes(oldRoutes, urlFilter);
+  });
+
+  /**
+   * @param {Array<{ route: string, file: string, pattern, string }>} routes
+   * @param {string} urlFilter
+   */
+  function updateRoutes(routes, urlFilter) {
+    const ul = document.querySelector(".route-list");
+    if (!ul) {
+      return;
+    }
+    ul.textContent = "";
+    const filteredRoutes = urlFilter.length > 0
+      ? routes.filter((route) => {
+        // Remove trailing slash
+        let f = urlFilter;
+        if (f.endsWith("/")) {
+          f = f.slice(0, -1);
+        }
+
+        // @ts-ignore
+        const urlPattern = new URLPattern(
+          route.pattern,
+          "http://localhost:8000/",
+        );
+        const url = new URL(f, "http://localhost:8000/");
+        return urlPattern.test(url);
+      })
+      : routes;
+
+    if (filteredRoutes.length === 0) {
+      const li = document.createElement("li");
+      li.className = "route-entry";
+      li.textContent = "No routes found";
+      ul.appendChild(li);
+      return;
+    }
+
+    for (const route of filteredRoutes) {
+      let cleanedRoute = route.route.replace(
+        /index$/,
+        "",
+      );
+
+      const li = document.createElement("li");
+      li.className = "route-entry";
+
+      li.addEventListener("click", () => {
+        if (selectedRoute) {
+          selectedRoute.classList.remove("selected");
+        }
+        selectedRoute = li;
+        selectedRoute.classList.add("selected");
+        vscode.postMessage({
+          type: "open",
+          value: route.file,
+        });
+      });
+
+      // Special routes:
+      const routeTypeMatcher = [
+        {
+          fileName: "_app.tsx",
+          name: "App Wrapper",
+          shortName: "App",
+          document: "https://fresh.deno.dev/docs/concepts/app-wrapper",
+        },
+        {
+          fileName: "_layout.tsx",
+          name: "Layout",
+          shortName: "Layout",
+          document: "https://fresh.deno.dev/docs/concepts/layouts",
+        },
+        {
+          fileName: "_middleware.ts",
+          name: "Middleware",
+          shortName: "Middleware",
+          document: "https://fresh.deno.dev/docs/concepts/middleware",
+        },
+        {
+          fileName: "_404.tsx",
+          name: "Error page",
+          shortName: "Error",
+          document: "https://fresh.deno.dev/docs/concepts/error-pages",
+        },
+        {
+          fileName: "_500.tsx",
+          name: "Error page",
+          shortName: "Error",
+          document: "https://fresh.deno.dev/docs/concepts/error-pages",
+        },
+      ];
+
+      const matched = routeTypeMatcher.find((matcher) =>
+        route.file.endsWith(matcher.fileName)
+      ) || {
+        name: "Route",
+        shortName: "Route",
+        document: "https://fresh.deno.dev/docs/concepts/routing",
+      };
+
+      const routeName = document.createElement("div");
+      routeName.className = "route-name";
+      li.appendChild(routeName);
+
+      if (matched.shortName === "Route") {
+        routeName.appendChild(createRouteIcon());
+      } else {
+        routeName.appendChild(createSpecialIcon());
+      }
+
+      let extLinkHref = `http://localhost:8000/${cleanedRoute}`;
+      let extLink = null;
+
+      // Create placeholder for route name
+      if (cleanedRoute.indexOf("[") === -1) {
+        // plain text
+        const routeNameLabel = document.createElement("div");
+        routeNameLabel.className = "route-label";
+        routeNameLabel.textContent = cleanedRoute || "/ (root)";
+        routeName.appendChild(routeNameLabel);
+      } else {
+        // with param
+        const routeNameLabel = document.createElement("div");
+        routeNameLabel.className = "route-label";
+        const parts = parseBrackets(cleanedRoute);
+
+        for (const part of parts) {
+          if (part.type === "literal") {
+            const span = document.createElement("span");
+            span.textContent = part.value;
+            routeNameLabel.appendChild(span);
+          } else if (part.type === "param") {
+            const input = document.createElement("input");
+            input.className = "route-param";
+            input.value = part.value;
+            input.placeholder = part.value;
+            input.addEventListener("click", (e) => {
+              e.stopPropagation();
+            });
+
+            // Update external link href when input changes
+            input.addEventListener("input", (e) => {
+              if (!extLink) {
+                return;
+              }
+              extLink.setAttribute(
+                "href",
+                `http://localhost:8000/${
+                  getTextContentChildren(routeNameLabel).join("")
+                }`,
+              );
+            });
+            routeNameLabel.appendChild(input);
+          }
+        }
+        extLinkHref = `http://localhost:8000/${
+          getTextContentChildren(routeNameLabel).join("")
+        }`;
+        routeName.appendChild(routeNameLabel);
+      }
+
+      const routeAction = document.createElement("div");
+      routeAction.className = "route-action";
+      li.appendChild(routeAction);
+
+      // Document Link
+      routeAction.appendChild(
+        createPreviewLink(matched.name, matched.document),
+      );
+
+      if (matched.shortName === "Route") {
+        extLink = createExternalIcon(
+          extLinkHref,
+        );
+        routeName.appendChild(
+          extLink,
+        );
+      }
+
+      ul.appendChild(li);
+    }
+
+    /**
+     * @param {string} href
+     * @returns {HTMLAnchorElement}
+     */
+    function createExternalIcon(href) {
+      const link = document.createElement("a");
+      link.className = "icon-link";
+      link.href = href;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      const icon = createIcon("#icon-external");
+      icon.setAttribute("width", "18");
+      icon.setAttribute("height", "18");
+      icon.setAttribute("viewBox", "0 0 20 21");
+      link.appendChild(icon);
+      return link;
+    }
+
+    /**
+     * @param {string} name
+     * @param {string} href
+     */
+    function createPreviewLink(name, href) {
+      const fileLink = document.createElement("a");
+      fileLink.className = "file-link";
+      fileLink.textContent = name;
+      fileLink.href = href;
+      return fileLink;
+    }
+  }
+
+  function createSpecialIcon() {
+    return createIcon("#icon-special");
+  }
+
+  /**
+   * @param {string} id
+   * @returns {SVGElement}
+   */
+  function createIcon(id) {
+    const icon = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "svg",
+    );
+    icon.setAttribute("width", "24");
+    icon.setAttribute("height", "25");
+    icon.setAttribute("viewBox", "0 0 24 25");
+    icon.classList.add("icon");
+
+    const useTag = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "use",
+    );
+    useTag.setAttributeNS(
+      "http://www.w3.org/1999/xlink",
+      "href",
+      id,
+    );
+    icon.appendChild(useTag);
+    return icon;
+  }
+
+  function createRouteIcon() {
+    return createIcon("#icon-path");
+  }
+
+  /**
+   * @param {HTMLElement} element
+   * @returns {string[]}
+   * @description Get text content of all children including input.value
+   */
+  function getTextContentChildren(element) {
+    const result = [];
+    for (const child of element.childNodes) {
+      if (child instanceof HTMLInputElement) {
+        result.push(child.value ?? "");
+      } else {
+        result.push(child.textContent ?? "");
+      }
+    }
+    return result;
+  }
+
+  /**
+   * parse brackets
+   * @param {string} input
+   * @returns
+   */
+  function parseBrackets(input) {
+    // input:
+    // "/users/[id]/[name]"
+    // output:
+    // { type: "literal", value: "/users/" }, { type: "param", value: "id" }, { type: "literal", value: "/" }, { type: "param", value: "name" }
+    const result = [];
+    let current = "";
+    let inBrackets = false;
+    for (let i = 0; i < input.length; i++) {
+      const char = input[i];
+      if (char === "[") {
+        if (current) {
+          result.push({ type: "literal", value: current });
+          current = "";
+        }
+        inBrackets = true;
+      } else if (char === "]") {
+        if (current) {
+          result.push({ type: "param", value: current });
+          current = "";
+        }
+        inBrackets = false;
+      } else {
+        current += char;
+      }
+    }
+    if (current) {
+      result.push({ type: "literal", value: current });
+    }
+    return result;
+  }
+
+  window.setInterval(() => {
+    vscode.postMessage({ type: "update" });
+  }, 10000);
+
+  vscode.postMessage({ type: "update" });
+})();

--- a/media/fresh/main.js
+++ b/media/fresh/main.js
@@ -1,3 +1,5 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
 /* eslint-disable @typescript-eslint/naming-convention */
 //@ts-check
 

--- a/media/fresh/vscode.css
+++ b/media/fresh/vscode.css
@@ -1,0 +1,91 @@
+:root {
+	--container-paddding: 20px;
+	--input-padding-vertical: 6px;
+	--input-padding-horizontal: 4px;
+	--input-margin-vertical: 4px;
+	--input-margin-horizontal: 0;
+}
+
+body {
+	padding: 0 var(--container-paddding);
+	color: var(--vscode-foreground);
+	font-size: var(--vscode-font-size);
+	font-weight: var(--vscode-font-weight);
+	font-family: var(--vscode-font-family);
+	background-color: var(--vscode-editor-background);
+}
+
+ol,
+ul {
+	padding-left: var(--container-paddding);
+}
+
+body > *,
+form > * {
+	margin-block-start: var(--input-margin-vertical);
+	margin-block-end: var(--input-margin-vertical);
+}
+
+*:focus {
+	outline-color: var(--vscode-focusBorder) !important;
+}
+
+a {
+	color: var(--vscode-textLink-foreground);
+}
+
+a:hover,
+a:active {
+	color: var(--vscode-textLink-activeForeground);
+}
+
+code {
+	font-size: var(--vscode-editor-font-size);
+	font-family: var(--vscode-editor-font-family);
+}
+
+button {
+	border: none;
+	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+	width: 100%;
+	text-align: center;
+	outline: 1px solid transparent;
+	outline-offset: 2px !important;
+	color: var(--vscode-button-foreground);
+	background: var(--vscode-button-background);
+}
+
+button:hover {
+	cursor: pointer;
+	background: var(--vscode-button-hoverBackground);
+}
+
+button:focus {
+	outline-color: var(--vscode-focusBorder);
+}
+
+button.secondary {
+	color: var(--vscode-button-secondaryForeground);
+	background: var(--vscode-button-secondaryBackground);
+}
+
+button.secondary:hover {
+	background: var(--vscode-button-secondaryHoverBackground);
+}
+
+input:not([type='checkbox']),
+textarea {
+	display: block;
+	width: 100%;
+	border: none;
+	font-family: var(--vscode-font-family);
+	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+	color: var(--vscode-input-foreground);
+	outline-color: var(--vscode-input-border);
+	background-color: var(--vscode-input-background);
+}
+
+input::placeholder,
+textarea::placeholder {
+	color: var(--vscode-input-placeholderForeground);
+}

--- a/media/fresh/vscode.css
+++ b/media/fresh/vscode.css
@@ -1,3 +1,5 @@
+/* Copyright 2018-2022 the Deno authors. All rights reserved. MIT license. */
+
 :root {
 	--container-paddding: 20px;
 	--input-padding-vertical: 6px;

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "onCommand:deno.client.welcome",
     "onCommand:deno.client.initializeWorkspace",
     "onCommand:deno.client.reloadImportRegistries",
-    "onWebviewPanel:welcomeDeno"
+    "onWebviewPanel:welcomeDeno",
+    "workspaceContains:fresh.gen.ts"
   ],
   "main": "./client/dist/main",
   "contributes": {
@@ -117,8 +118,82 @@
         "title": "Welcome",
         "category": "Deno",
         "description": "Open the welcome page for the Deno extension."
+      },
+      {
+        "command": "deno.fresh.generateRoute",
+        "title": "New Route Component",
+        "when": "is-fresh-project"
+      },
+      {
+        "command": "deno.fresh.generateLayout",
+        "title": "New Layout",
+        "when": "is-fresh-project"
+      },
+      {
+        "command": "deno.fresh.generateComponent",
+        "title": "New Component",
+        "when": "is-fresh-project"
+      },
+      {
+        "command": "deno.fresh.generateIsland",
+        "title": "New Island Component",
+        "when": "is-fresh-project"
       }
     ],
+    "views": {
+      "explorer": [
+        {
+          "type": "webview",
+          "id": "deno.fresh.routeView",
+          "name": "Fresh Routes",
+          "when": "is-fresh-project"
+        }
+      ]
+    },    
+    "menus": {
+      "explorer/context": [
+        {
+          "when": "is-fresh-project && explorerResourceIsFolder && resourceFilename =~ /routes/",
+          "command": "deno.fresh.generateRoute",
+          "group": "Fresh"
+        },
+        {
+          "when": "is-fresh-project && explorerResourceIsFolder && resourceDirname =~ /routes/",
+          "command": "deno.fresh.generateRoute",
+          "group": "Fresh"
+        },
+        {
+          "when": "is-fresh-project && explorerResourceIsFolder && resourceFilename =~ /islands/",
+          "command": "deno.fresh.generateIsland",
+          "group": "Fresh"
+        },
+        {
+          "when": "is-fresh-project && explorerResourceIsFolder && resourceDirname =~ /islands/",
+          "command": "deno.fresh.generateIsland",
+          "group": "Fresh"
+        },
+        {
+          "when": "is-fresh-project && explorerResourceIsFolder && resourceFilename =~ /components/",
+          "command": "deno.fresh.generateComponent",
+          "group": "Fresh"
+        },
+        {
+          "when": "is-fresh-project && explorerResourceIsFolder && resourceDirname =~ /components/",
+          "command": "deno.fresh.generateComponent",
+          "group": "Fresh"
+        },
+        {
+          "when": "is-fresh-project && explorerResourceIsFolder && resourceFilename =~ /routes/",
+          "command": "deno.fresh.generateLayout",
+          "group": "Fresh"
+        },
+        {
+          "when": "is-fresh-project && explorerResourceIsFolder && resourceDirname =~ /routes/",
+          "command": "deno.fresh.generateLayout",
+          "group": "Fresh"
+        }
+      ]
+    },
     "configuration": {
       "type": "object",
       "title": "Deno",


### PR DESCRIPTION
This PR introduces Fresh features:

# Route view

<img width="470" alt="image" src="https://github.com/denoland/vscode_deno/assets/3132889/e639b1fc-82f4-4f7b-8b3d-865d5feb5455">

The Route view is designed as a live documentation, especially for beginners of Fresh.

- Special files like `_app.tsx` are displayed with distinct icons and are accompanied by links to the documentation. This prevents beginners from being confused when they encounter these files right after initializing a project.
- URL Tester for testing dynamic routes.
- Parameters for dynamic routes can be entered directly into a text input, and can be previewed in a browser with the icon on the right.

**Constraints:**

Users need to start the Fresh server before the browser preview. Also, the URL is fixed at http://localhost:8000/.

**Note:**

The Fresh routes view should not appear in non-Fresh projects as it checks `fresh.gen.ts`. I believe I haven't changed the behavior of the existing Deno extension, but please let me know if there are any oversights.


# Code template

<img width="481" alt="image" src="https://github.com/denoland/vscode_deno/assets/3132889/c2426e84-64ca-4ca4-a620-72dd6ef423e4">

<img width="401" alt="image" src="https://github.com/denoland/vscode_deno/assets/3132889/e3b67980-b469-4bac-a7e2-c02f2a9f67fa">


# Code snippets

<img width="698" alt="image" src="https://github.com/denoland/vscode_deno/assets/3132889/dcfff07c-4c60-48d6-9c1e-4fb4831217d1">
