### PR TITLE
fix: increase client shutdown timeout from 2s to 10s

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -141,7 +141,8 @@ export function startLanguageServer(
       extensionContext.testController = undefined;
       extensionContext.statusBar.refresh(extensionContext);
       vscode.commands.executeCommand("setContext", ENABLEMENT_FLAG, false);
-      await client.stop(1e4);
+      const timeoutMs = 10_000;
+      await client.stop(timeoutMs);
     }
 
     // Start a new language server

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -141,7 +141,7 @@ export function startLanguageServer(
       extensionContext.testController = undefined;
       extensionContext.statusBar.refresh(extensionContext);
       vscode.commands.executeCommand("setContext", ENABLEMENT_FLAG, false);
-      await client.stop();
+      await client.stop(1e4);
     }
 
     // Start a new language server


### PR DESCRIPTION
There's a big chunk of blocking sync IO we do on the main LSP thread at https://github.com/denoland/deno/blob/v1.37.1/cli/lsp/documents.rs#L1437-L1448. I tried moving it to a blocking thread with a cancellation token triggered on shutdown, but something else was still blocking the shutdown notification from being received.

Either way, It would be good to increase this timeout for projects with large dep graphs like fresh.

cc @marvinhagemeister 