### PR TITLE
fix(fresh): add fs error handling

### DIFF
--- a/client/src/fresh/extension.ts
+++ b/client/src/fresh/extension.ts
@@ -22,7 +22,13 @@ async function isFreshProject() {
     workspace,
     "fresh.gen.ts",
   );
-  return await vscode.workspace.fs.stat(vscode.Uri.file(freshGenPath));
+  let fileExists = null;
+  try {
+    fileExists = await vscode.workspace.fs.stat(vscode.Uri.file(freshGenPath))
+  } catch (_error) {
+    // do nothing
+  }
+  return !!fileExists;
 }
 export function activate(context: vscode.ExtensionContext) {
   isFreshProject().then((isFresh) => {

--- a/client/src/fresh/getRoutes.ts
+++ b/client/src/fresh/getRoutes.ts
@@ -120,7 +120,12 @@ export async function getAllRoutes() {
 
   const filename = `${projectPath}/fresh.gen.ts`;
 
-  const input = await fs.promises.readFile(filename, "utf8");
+  let input = "";
+  try {
+    input = await fs.promises.readFile(filename, "utf8");
+  } catch (_error) {
+    return [];
+  }
 
   const routes: Routes[] = input.split("\n").filter((line: string) =>
     line.includes("./routes") && !line.includes("import")


### PR DESCRIPTION
sorry, I noticed that the fresh extension generates an error log in the Extension Host logs when 'fresh.gen.ts' is not found.

```log
2023-10-03 15:36:52.092 [error] EntryNotFound (FileSystemError): Error: ENOENT: no such file or directory, stat '/Users/hashrock/code/temp/fresh-pj-2/fresh.gen.ts'
    at Function.e (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:109:26741)
    at Object.stat (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:109:24556)
    at isFreshProject (/Users/hashrock/code/denoland/vscode_deno/client/src/fresh/extension.ts:25:10)
```

I've added error handling for both `fs.stat` and `fs.promises.readFile`.
