### PR TITLE
refactor: move "deno.reloadImportRegistries" command to the server

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -412,10 +412,18 @@ export async function activate(
   // Register any commands.
   const registerCommand = createRegisterCommand(context);
   const builtinCommands = await vscode.commands.getCommands();
-  // TODO(nayeemrmn): As of Deno 1.37.0, the `deno.cache` command is implemented
-  // on the server. Remove this eventually.
+  // TODO(nayeemrmn): As of Deno 1.37.0, this command is implemented on the
+  // server. Remove this eventually.
   if (!builtinCommands.includes("deno.cache")) {
     registerCommand("deno.cache", commands.cache);
+  }
+  // TODO(nayeemrmn): As of Deno 1.37.2, this command is implemented on the
+  // server. Remove this eventually.
+  if (!builtinCommands.includes("deno.reloadImportRegistries")) {
+    registerCommand(
+      "deno.reloadImportRegistries",
+      commands.reloadImportRegistries,
+    );
   }
   // TODO(nayeemrmn): Change the LSP's invocations of this to
   // `deno.client.showReferences`. Remove this one eventually.
@@ -428,11 +436,6 @@ export async function activate(
   if (!builtinCommands.includes("deno.test")) {
     registerCommand("deno.test", commands.test);
   }
-  // TODO(nayeemrmn): Move server-side as `deno.reloadImportRegistries`.
-  registerCommand(
-    "deno.client.reloadImportRegistries",
-    commands.reloadImportRegistries,
-  );
   registerCommand("deno.client.test", commands.test);
   registerCommand(
     "deno.client.cacheActiveDocument",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "onDebugResolve:javascriptreact",
     "onCommand:deno.client.welcome",
     "onCommand:deno.client.initializeWorkspace",
-    "onCommand:deno.client.reloadImportRegistries",
+    "onCommand:deno.reloadImportRegistries",
     "onWebviewPanel:welcomeDeno"
   ],
   "main": "./client/dist/main",
@@ -93,7 +93,7 @@
         "description": "Initialize the workspace configuration for Deno."
       },
       {
-        "command": "deno.client.reloadImportRegistries",
+        "command": "deno.reloadImportRegistries",
         "title": "Reload Import Registries Cache",
         "category": "Deno",
         "description": "Reload any cached import registry responses.",


### PR DESCRIPTION
This will let other editors use it for free. I'll actually add the command on the LSP after this lands (https://github.com/denoland/deno/pull/20823), I want to include the date for this change in a comment there. Backwards-compatible.