### PR TITLE
fix: update tasks sidebar on config change notification

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -396,11 +396,14 @@ export async function activate(
       treeDataProvider.refresh();
     }
   }));
-  context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((event) => {
-    if (event.uri.fsPath.match(/\/deno\.jsonc?$/)) {
-      treeDataProvider.refresh();
-    }
-  }));
+  context.subscriptions.push(
+    extensionContext.client!.onNotification(
+      "deno/didChangeDenoConfiguration",
+      () => {
+        treeDataProvider.refresh();
+      },
+    ),
+  );
   context.subscriptions.push(vscode.workspace.onDidRenameFiles((event) => {
     if (
       event.files.some(({ oldUri: uri }) => uri.fsPath.match(/\/deno\.jsonc?$/))

--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -42,6 +42,7 @@ export const registryState = new NotificationType<RegistryStateParams>(
 export interface TaskRequestResponse {
   name: string;
   detail: string;
+  sourceUri: string;
 }
 
 /** Requests any tasks from the language server that the language server is

--- a/client/src/tasks_sidebar.ts
+++ b/client/src/tasks_sidebar.ts
@@ -117,7 +117,6 @@ function buildDenoConfigTask(
   sourceUri: Uri,
 ): Task {
   const execution = new ProcessExecution(process, ["task", name]);
-  scope.uri.fs;
   const task = new Task(
     { type: "deno", name, command, sourceUri },
     scope,


### PR DESCRIPTION
Fixes #963. Coupled with https://github.com/denoland/deno/pull/20827. The tasks sidebar will now only work with Deno 1.37.2 or whichever version that PR lands for, since it depends on the `sourceUri` being included in task definitions.