### PR TITLE
fix: show error message for workspace init failure

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -114,8 +114,12 @@ export function initializeWorkspace(
       await vscode.window.showInformationMessage(
         "Deno is now setup in this workspace.",
       );
-    } catch {
-      vscode.window.showErrorMessage("Deno project initialization failed.");
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        `Deno project initialization failed: ${
+          (error as Error).message ?? error
+        }`,
+      );
     }
   };
 }


### PR DESCRIPTION
Fixes #582. Now shows:

```
Deno project initialization failed: Unable to write to Workspace Settings because no workspace is opened. Please open a workspace first and try again.
```