### PR TITLE
chore: remove compat paths for lsp < 1.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,21 @@ extension has the following configuration options:
   APIs. This is the equivalent to using `--unstable` on the command line.
   _boolean, default `false`_
 
+## Compatibility
+
+To see which versions of the Deno CLI are compatible with which versions of this
+extension, consult the following table.
+
+| vscode-deno  | Deno CLI       |
+| ------------ | -------------- |
+| TODO onwards | 1.37.0 onwards |
+| ? - 3.27.0   | ? - 1.36.4     |
+
+Version ranges are inclusive. Incompatibilites prior to 3.27.0 were not tracked.
+
 ## Contribute
 
 [Learn how to setup & contribute to this project](.github/CONTRIBUTING.md)
-
 
 ## Thanks
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -130,14 +130,6 @@ function getWorkspaceSettings(): Settings {
   const workspaceSettings = Object.create(null);
   for (const key of workspaceSettingsKeys) {
     workspaceSettings[key] = config.get(key);
-    // TODO(nayeemrmn): Deno LSP versions < 1.37.0 require `deno.enable` to be
-    // non-null. Eventually remove this.
-    if (
-      semver.lt(extensionContext.serverInfo?.version ?? "1.0.0", "1.37.0-rc") &&
-      key == "enable"
-    ) {
-      workspaceSettings[key] ??= false;
-    }
   }
   workspaceSettings.javascript = Object.create(null);
   workspaceSettings.typescript = Object.create(null);
@@ -393,12 +385,6 @@ export async function activate(
   handleDocumentOpen(...vscode.workspace.textDocuments);
 
   await commands.startLanguageServer(context, extensionContext)();
-  // TODO(nayeemrmn): Deno LSP versions < 1.37.0 has different compat logic.
-  // We restart here if it's detected. Eventually remove this.
-  if (!semver.lt(extensionContext.serverInfo!.version, "1.37.0-rc")) {
-    extensionContext.workspaceSettings = getWorkspaceSettings();
-    await commands.startLanguageServer(context, extensionContext)();
-  }
 
   const treeDataProvider = registerSidebar(
     extensionContext,


### PR DESCRIPTION
I want to get rid of this double server startup ASAP -- it exacerbates https://github.com/denoland/deno/issues/20700 because it leads to an extra background server process that doesn't exit.