### PR TITLE
chore: default "deno.enablePaths" to null

### DIFF
--- a/client/src/enable.ts
+++ b/client/src/enable.ts
@@ -41,10 +41,7 @@ export async function getWorkspacesEnabledInfo() {
     }
 
     // check for specific paths being enabled
-    const enabledPaths = config.get<string[]>(ENABLE_PATHS);
-    // We convert `enablePaths: []` to `enablePaths: null` for now.
-    // See https://github.com/denoland/vscode_deno/issues/908.
-    if (enabledPaths && enabledPaths.length) {
+    if (config.get<string[]>(ENABLE_PATHS)) {
       return true;
     }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -110,9 +110,7 @@ function getPathFilters(): PathFilter[] {
       vscode.Uri.joinPath(workspaceFolder.uri, p).fsPath
     );
     const enabled_ = config.get<string[]>(ENABLE_PATHS);
-    // We convert `enablePaths: []` to `enablePaths: null` for now.
-    // See https://github.com/denoland/vscode_deno/issues/908.
-    const enabled = enabled_?.length
+    const enabled = enabled_
       ? enabled_.map((p) => vscode.Uri.joinPath(workspaceFolder.uri, p).fsPath)
       : null;
     if (disabled.length === 0 && enabled == null) {

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -93,7 +93,7 @@ export interface Settings {
   disablePaths: string[];
   /** If set, indicates that only the paths in the workspace should be Deno
    * enabled. */
-  enablePaths: string[];
+  enablePaths: string[] | null;
   /** A path to an import map that should be applied. */
   importMap: string | null;
   /** Options related to the display of inlay hints. */

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
           "items": {
             "type": "string"
           },
-          "default": [],
+          "default": null,
           "markdownDescription": "Enables the Deno Language Server for specific paths, instead of for the whole workspace folder. This will disable the built in TypeScript/JavaScript language server for those paths.\n\nWhen a value is set, the value of `\"deno.enable\"` is ignored.\n\nThe workspace folder is used as the base for the supplied paths. If for example you have all your Deno code in `worker` path in your workspace, you can add an item with the value of `./worker`, and the Deno will only provide diagnostics for the files within `worker` or any of its sub paths.\n\n**Not recommended to be enabled in user settings.**",
           "scope": "resource",
           "examples": [

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -36,7 +36,7 @@ const defaultSettings: Settings = {
   certificateStores: null,
   enable: null,
   disablePaths: [],
-  enablePaths: [],
+  enablePaths: null,
   codeLens: null,
   config: null,
   documentPreloadLimit: null,


### PR DESCRIPTION
Towards #908. For the last step we have to wait some more version cycles and then remove this code from the server: https://github.com/denoland/deno/blob/v1.39.4/cli/lsp/config.rs#L793-L795. No changes are required to the compat table since it already excludes whatever version pairs this would affect.