### PR TITLE
refactor: clean up enable settings on plugin interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ The extension provides several commands:
   > provide a quick fix to fetch and cache those dependencies, which invokes
   > this command for you.
 
-- _Deno: Enable_ - will enabled Deno on the current workspace. Alternatively
-  you can create a `deno.json` or `deno.jsonc` file at the root of your
-  workspace.
+- _Deno: Enable_ - will enable Deno on the current workspace. Alternatively you
+  can create a `deno.json` or `deno.jsonc` file at the root of your workspace.
 - _Deno: Language Server Status_ - displays a page of information about the
   status of the Deno Language Server. Useful when submitting a bug about the
   extension or the language server.
@@ -225,10 +224,11 @@ extension has the following configuration options:
 To see which versions of the Deno CLI are compatible with which versions of this
 extension, consult the following table.
 
-| vscode-deno    | Deno CLI       |
-| -------------- | -------------- |
-| 3.28.0 onwards | 1.37.0 onwards |
-| ? - 3.27.0     | ? - 1.36.4     |
+| vscode-deno     | Deno CLI       |
+| --------------- | -------------- |
+| 3.32.0 onwards  | 1.37.1 onwards |
+| 3.28.0 - 3.31.0 | 1.37.0 onwards |
+| ? - 3.27.0      | ? - 1.36.4     |
 
 Version ranges are inclusive. Incompatibilites prior to 3.27.0 were not tracked.
 

--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -19,17 +19,6 @@ import type {
   TextDocumentIdentifier,
 } from "vscode-languageclient";
 
-export interface CacheParams {
-  referrer: TextDocumentIdentifier;
-  uris: TextDocumentIdentifier[];
-}
-
-export const cache = new RequestType<CacheParams, boolean, void>("deno/cache");
-
-export const reloadImportRegistries = new RequestType0<boolean, void>(
-  "deno/reloadImportRegistries",
-);
-
 export interface RegistryStateParams {
   origin: string;
   suggestions: boolean;

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -1,151 +1,15 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import type { ConfigurationScope } from "vscode";
-
 // types shared with typescript-deno-plugin
 
-/** Settings under `typescript.format` and `javascript.format`. These are passed
- * through to the LSP without documentation here. */
-export interface Format {
-  [key: string]: unknown;
-}
-
-/** Settings under `typescript.preferences` and `javascript.preferences`. These
- * are passed through to the LSP without documentation here. */
-export interface Preferences {
-  [key: string]: unknown;
-}
-
-export interface InlayHints {
-  parameterNames: {
-    /** Enable/disable inlay hints for parameter names. */
-    enabled: "none" | "literals" | "all";
-    /** Do not display an inlay hint when the argument name matches the parameter. */
-    suppressWhenArgumentMatchesName: boolean;
-  } | null;
-  /** Enable/disable inlay hints for implicit parameter types. */
-  parameterTypes: { enabled: boolean } | null;
-  variableTypes: {
-    /** Enable/disable inlay hints for implicit variable types. */
-    enabled: boolean;
-    /** Suppress type hints where the variable name matches the implicit type. */
-    suppressWhenTypeMatchesName: boolean;
-  } | null;
-  /** Enable/disable inlay hints for implicit property declarations. */
-  propertyDeclarationTypes: { enabled: boolean } | null;
-  /** Enable/disable inlay hints for implicit function return types. */
-  functionLikeReturnTypes: { enabled: boolean } | null;
-  /** Enable/disable inlay hints for enum values. */
-  enumMemberValues: { enabled: boolean } | null;
-}
-
-export interface Suggest {
-  autoImports: boolean;
-  completeFunctionCalls: boolean;
-  names: boolean;
-  paths: boolean;
-}
-
-// Subset of the "javascript" and "typescript" config sections.
-export interface LanguageSettings {
-  format: Format;
-  implementationsCodeLens: unknown;
-  inlayHints: InlayHints | null;
-  preferences: Preferences | null;
-  referencesCodeLens: unknown;
-  suggest: Suggest | null;
-  updateImportsOnFileMove: {
-    enabled: "always" | "prompt" | "never";
-  } | null;
-}
-
-/** When `vscode.WorkspaceSettings` get serialized, they keys of the
- * configuration are available.  This interface should mirror the configuration
- * contributions made by the extension.
- *
- * **WARNING** please ensure that the `workspaceSettingsKeys` contains all the
- * top level keys of this, as they need to be sent to the server on
- * initialization.
- */
-export interface Settings {
-  /** Specify an explicit path to the `deno` cache instead of using DENO_DIR
-   * or the OS default. */
-  cache: string | null;
-  certificateStores: string[] | null;
-  /** Settings related to code lens. */
-  codeLens: {
-    implementations: boolean;
-    references: boolean;
-    referencesAllFunctions: boolean;
-    test: boolean;
-    testArgs: string[];
-  } | null;
-  /** A path to a configuration file that should be applied. */
-  config: string | null;
-  /** Maximum number of file system entries to traverse when preloading. */
-  documentPreloadLimit: number | null;
-  maxTsServerMemory: number | null;
-  /** Is the extension enabled or not. */
+export interface EnableSettings {
   enable: boolean | null;
-  /** Controls if the extension should cache the active document's dependencies on save. */
-  cacheOnSave: boolean;
-  /** Paths in the workspace that should be Deno enabled. */
-  disablePaths: string[];
-  /** If set, indicates that only the paths in the workspace should be Deno
-   * enabled. */
   enablePaths: string[] | null;
-  /** A path to an import map that should be applied. */
-  importMap: string | null;
-  /** Options related to the display of inlay hints. */
-  // TODO(nayeemrmn): Deprecate in favour of `LanguageSettings::inlayHints`.
-  inlayHints: InlayHints | null;
-  /** A flag that enables additional internal debug information to be printed
-   * to the _Deno Language Server_ output. */
-  internalDebug: boolean;
-  internalInspect: boolean | string;
-  /** Determine if the extension should be providing linting diagnostics. */
-  lint: boolean;
-  logFile: boolean;
-  /** Specify an explicit path to the `deno` binary. */
-  path: string | null;
-  // TODO(nayeemrmn): Deprecate the `Suggest` part of this in favour of
-  // `LanguageSettings::suggest`.
-  suggest:
-    | Suggest & {
-      imports: {
-        autoDiscover: boolean;
-        hosts: Record<string, boolean>;
-      } | null;
-    }
-    | null;
-  testing: { args: string[] } | null;
-  tlsCertificate: string | null;
-  unsafelyIgnoreCertificateErrors: string[] | null;
-  /** Determine if the extension should be type checking against the unstable
-   * APIs. */
-  unstable: boolean;
-  javascript?: LanguageSettings | null;
-  typescript?: LanguageSettings | null;
-}
-
-export interface PathFilter {
-  /** The file system path of the workspace folder that is partially enabled. */
-  workspace: string;
-  /** The file system paths that are Deno disabled. */
-  disabled: string[];
-  /** The file system paths that are Deno enabled. */
-  enabled: string[] | null;
+  disablePaths: string[];
 }
 
 export interface PluginSettings {
-  documents: Record<string, DocumentSettings>;
-  pathFilters: PathFilter[];
-  /** Whether or not there is a `deno.json{c,}` at the workspace root. */
-  hasDenoConfig: boolean;
-  workspace: Settings;
-}
-
-export interface DocumentSettings {
-  scope: ConfigurationScope;
-  settings: Partial<Settings>;
+  enableSettingsUnscoped: EnableSettings;
+  enableSettingsByFolder: [string, EnableSettings][];
+  scopesWithDenoJson: string[];
 }

--- a/client/src/status_bar.ts
+++ b/client/src/status_bar.ts
@@ -30,11 +30,13 @@ export class DenoStatusBar {
 
     // show only when "enable" is true and language server started
     if (
-      ((extensionContext.workspaceSettings.enable ??
-        extensionContext.hasDenoConfig) ||
-        extensionContext.pathFilters.length !== 0) &&
-      extensionContext.client &&
-      extensionContext.serverInfo
+      extensionContext.client && extensionContext.serverInfo &&
+      (extensionContext.scopesWithDenoJson.length != 0 ||
+        extensionContext.enableSettingsUnscoped.enable ||
+        extensionContext.enableSettingsUnscoped.enablePaths?.length ||
+        extensionContext.enableSettingsByFolder.find(([_, s]) =>
+          s.enable || s.enablePaths?.length
+        ))
     ) {
       this.#inner.show();
     } else {

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -5,11 +5,12 @@ import type {
   LanguageClientOptions,
 } from "vscode-languageclient/node";
 import type { DenoServerInfo } from "./server_info";
-import type { DocumentSettings, PathFilter, Settings } from "./shared_types";
+import type { EnableSettings } from "./shared_types";
 import type { DenoStatusBar } from "./status_bar";
 import type * as vscode from "vscode";
 
 import type { ServerCapabilities } from "vscode-languageclient";
+import { DenoTasksTreeDataProvider } from "./tasks_sidebar";
 
 export * from "./shared_types";
 
@@ -27,9 +28,6 @@ interface DenoExperimental {
 export interface DenoExtensionContext {
   client: LanguageClient | undefined;
   clientOptions: LanguageClientOptions;
-  /** A record of filepaths and their document settings. */
-  documentSettings: Record<string, DocumentSettings>;
-  pathFilters: PathFilter[];
   serverInfo: DenoServerInfo | undefined;
   /** The capabilities returned from the server. */
   serverCapabilities:
@@ -38,10 +36,12 @@ export interface DenoExtensionContext {
   statusBar: DenoStatusBar;
   testController: vscode.TestController | undefined;
   tsApi: TsApi;
-  hasDenoConfig: boolean;
-  /** The current workspace settings. */
-  workspaceSettings: Settings;
   outputChannel: vscode.OutputChannel;
+  tasksSidebar: DenoTasksTreeDataProvider;
+  maxTsServerMemory: number | null;
+  enableSettingsUnscoped: EnableSettings;
+  enableSettingsByFolder: [string, EnableSettings][];
+  scopesWithDenoJson: string[];
 }
 
 export interface TestCommandOptions {


### PR DESCRIPTION
Align enable-checks with how they are done in the server in preparation for multi-deno.json support.

This exposed lots of cruft in the way we were handling workspace settings, e.g. still storing and refreshing per-document settings, our explicit type definitions for them being redundant and other things.

Also remove compat paths for LSP versions <= 1.37.0.