### PR TITLE
feat: accept notifications for subdirectory deno.json files

### DIFF
--- a/client/src/enable.ts
+++ b/client/src/enable.ts
@@ -94,12 +94,12 @@ export async function setupCheckConfig(
     if (!uri) {
       return;
     }
-    extensionContext.scopesWithDenoJson = [];
+    extensionContext.scopesWithDenoJson = new Set();
     if (
       await exists(vscode.Uri.joinPath(uri, "./deno.json")) ||
       await exists(vscode.Uri.joinPath(uri, "./deno.jsonc"))
     ) {
-      extensionContext.scopesWithDenoJson.push(uri.fsPath);
+      extensionContext.scopesWithDenoJson.add(uri.fsPath);
     }
     extensionContext.tsApi?.refresh();
   }

--- a/client/src/status_bar.ts
+++ b/client/src/status_bar.ts
@@ -31,7 +31,7 @@ export class DenoStatusBar {
     // show only when "enable" is true and language server started
     if (
       extensionContext.client && extensionContext.serverInfo &&
-      (extensionContext.scopesWithDenoJson.length != 0 ||
+      (extensionContext.scopesWithDenoJson?.size ||
         extensionContext.enableSettingsUnscoped.enable ||
         extensionContext.enableSettingsUnscoped.enablePaths?.length ||
         extensionContext.enableSettingsByFolder.find(([_, s]) =>

--- a/client/src/testing.ts
+++ b/client/src/testing.ts
@@ -11,14 +11,13 @@ import {
   testRunCancel,
   testRunProgress,
 } from "./lsp_extensions";
-import type { DenoExtensionContext } from "./types";
-import { assert } from "./util";
 
 import * as vscode from "vscode";
 import { FeatureState, MarkupKind } from "vscode-languageclient/node";
 import type {
   ClientCapabilities,
   DocumentSelector,
+  LanguageClient,
   MarkupContent,
   ServerCapabilities,
   StaticFeature,
@@ -136,19 +135,13 @@ export class DenoTestController implements vscode.Disposable {
   #runCount = 0;
   #runs = new Map<number, vscode.TestRun>();
   #subscriptions: vscode.Disposable[] = [];
-  #testController: vscode.TestController;
 
-  constructor(extensionContext: DenoExtensionContext) {
-    const testController = extensionContext.testController =
-      this
-        .#testController =
-        vscode.tests
-          .createTestController("denoTestController", "Deno");
+  constructor(client: LanguageClient) {
+    const testController = vscode.tests.createTestController(
+      "denoTestController",
+      "Deno",
+    );
     this.#subscriptions.push(testController);
-
-    const { client } = extensionContext;
-    assert(client);
-
     const runHandler = async (
       request: vscode.TestRunRequest,
       cancellation: vscode.CancellationToken,

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -27,21 +27,21 @@ interface DenoExperimental {
 
 export interface DenoExtensionContext {
   client: LanguageClient | undefined;
+  clientSubscriptions: { dispose(): unknown }[] | undefined;
   clientOptions: LanguageClientOptions;
   serverInfo: DenoServerInfo | undefined;
   /** The capabilities returned from the server. */
   serverCapabilities:
     | ServerCapabilities<DenoExperimental>
     | undefined;
+  scopesWithDenoJson: Set<string> | undefined;
   statusBar: DenoStatusBar;
-  testController: vscode.TestController | undefined;
   tsApi: TsApi;
   outputChannel: vscode.OutputChannel;
   tasksSidebar: DenoTasksTreeDataProvider;
   maxTsServerMemory: number | null;
   enableSettingsUnscoped: EnableSettings;
   enableSettingsByFolder: [string, EnableSettings][];
-  scopesWithDenoJson: string[];
 }
 
 export interface TestCommandOptions {
@@ -55,4 +55,15 @@ export interface UpgradeAvailable {
 
 export interface DidUpgradeCheckParams {
   upgradeAvailable: UpgradeAvailable | null;
+}
+
+export interface DenoConfigurationChangeEvent {
+  scopeUri: string;
+  fileUri: string;
+  type: "added" | "changed" | "removed";
+  configurationType: "denoJson" | "packageJson";
+}
+
+export interface DidChangeDenoConfigurationParams {
+  changes: DenoConfigurationChangeEvent[];
 }


### PR DESCRIPTION
This completes the client-side changes for https://github.com/denoland/deno/pull/21029.

Also fixes disposable handling for resources created with the language client. Some were only being disposed when the extension deactivated, now their lifetimes are properly tied to the client. There were no bugs from this as far as I can tell. Just dangling event handlers.