### PR TITLE
feat: add workspace and jsr fields to lockfile schema

### DIFF
--- a/schemas/lockfile.schema.json
+++ b/schemas/lockfile.schema.json
@@ -53,6 +53,23 @@
             "description": "The full specifier as the value for the shortened specifier as the key."
           }
         },
+        "jsr": {
+          "type": "object",
+          "description": "Mapping between resolved jsr specifiers and their associated info.",
+          "default": {},
+          "additionalProperties": {
+            "type": "object",
+            "description": "Info associated with a jsr module.",
+            "default": {},
+            "properties": {
+              "dependencies": {
+                "type": "array",
+                "items": { "type": "string" },
+                "uniqueItems": true
+              }
+            }
+          }
+        },
         "npm": {
           "type": "object",
           "description": "A map of npm package names and versions to their respective hashes.",
@@ -75,6 +92,54 @@
                   "description": "The package name as the key to the package name + version as the value."
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    "workspace": {
+      "$ref": "#/definitions/workspaceMemberConfigContent",
+      "default": {},
+      "properties": {
+        "members": {
+          "type": "object",
+          "default": {},
+          "additionalProperties": {
+            "type": "object",
+            "default": {},
+            "properties": {
+              "dependencies": {
+                "type": "array",
+                "items": { "type": "string" },
+                "uniqueItems": true
+              },
+              "packageJson": {
+                "type": "object",
+                "default": {},
+                "properties": {
+                  "dependencies": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "uniqueItems": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "dependencies": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "packageJson": {
+          "type": "object",
+          "default": {},
+          "properties": {
+            "dependencies": {
+              "type": "array",
+              "items": { "type": "string" },
+              "uniqueItems": true
             }
           }
         }


### PR DESCRIPTION
Closes #1037.

Implements the changes to `LockfileContent` in https://github.com/denoland/deno_lockfile/commit/c263e012deac9733c3077ebadf81d0b2647dc204. I'm not confident in figuring out meaningful descriptions so if the field doesn't have a doc comment in rust, it's missing here.