### PR TITLE
chore: rename "deno/task" request to "deno.taskDefinitions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,15 @@ extension has the following configuration options:
 
 ## Compatibility
 
-To see which versions of the Deno CLI are compatible with which versions of this
-extension, consult the following table.
+To see which versions of this extension can be used with each version of the
+Deno CLI, consult the following table.
 
-| vscode-deno     | Deno CLI       |
-| --------------- | -------------- |
-| 3.32.0 onwards  | 1.37.1 onwards |
-| 3.28.0 - 3.31.0 | 1.37.0 onwards |
-| ? - 3.27.0      | ? - 1.36.4     |
+| Deno CLI       | vscode-deno     |
+| -------------- | --------------- |
+| 1.37.2 onwards | TODO onwards    |
+| 1.37.1         | 3.32.0 - 3.33.3 |
+| 1.37.0         | 3.28.0 - 3.31.0 |
+| ? - 1.36.4     | 3.27.0          |
 
 Version ranges are inclusive. Incompatibilites prior to 3.27.0 were not tracked.
 

--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -40,7 +40,7 @@ export const task = new RequestType0<
   TaskRequestResponse[] | undefined,
   void
 >(
-  "deno/task",
+  "deno/taskDefinitions",
 );
 
 export interface TestData {

--- a/client/src/tasks_sidebar.ts
+++ b/client/src/tasks_sidebar.ts
@@ -157,11 +157,6 @@ class DenoTaskProvider implements TaskProvider {
       try {
         const configTasks = await client.sendRequest(taskReq);
         for (const { name, detail: command, sourceUri } of configTasks ?? []) {
-          // TODO(nayeemrmn): Deno LSP versions < 1.37.2 doesn't provide the
-          // `sourceUri`. Remove this eventually.
-          if (!sourceUri) {
-            continue;
-          }
           const workspaceFolder = (workspace.workspaceFolders ?? []).find((f) =>
             // NOTE: skipEncoding in Uri.toString(), read more at https://github.com/microsoft/vscode/commit/65cb3397673b922c1b6759d145a3a183feb3ee5d
             sourceUri

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -20,8 +20,8 @@ export interface TsApi {
 }
 
 interface DenoExperimental {
-  /** Support for the `deno/task` request, which returns any tasks that are
-   * defined in configuration files. */
+  /** Support for the `deno/taskDefinitions` request, which returns any tasks
+   * that are defined in configuration files. */
   denoConfigTasks?: boolean;
 }
 


### PR DESCRIPTION
Towards TODO mentioned in https://github.com/denoland/deno/blob/v1.40.2/cli/lsp/mod.rs#L66-L68. This bumps the minimum required CLI version from 1.37.1 to 1.37.2. I also inverted the compat table, since the CLI version is more likely to be fixed for the user.