### PR TITLE
feat: restore init workspace command as alias

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -216,6 +216,8 @@ export async function activate(
   registerCommand("deno.client.status", commands.status);
   registerCommand("deno.client.welcome", commands.welcome);
   registerCommand("deno.client.enable", commands.enable);
+  // Legacy alias for `deno.client.enable`.
+  registerCommand("deno.client.initializeWorkspace", commands.enable);
   registerCommand("deno.client.disable", commands.disable);
   registerCommand("deno.client.statusBarClicked", commands.statusBarClicked);
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,12 @@
         "description": "Enable the Deno language server via workspace settings. This isn't necessary if your workspace root contains a `deno.json` file."
       },
       {
+        "command": "deno.client.initializeWorkspace",
+        "title": "Initialize Workspace Configuration",
+        "category": "Deno",
+        "description": "Legacy alias for the 'Deno: Enable' command."
+      },
+      {
         "command": "deno.client.disable",
         "title": "Disable",
         "category": "Deno",


### PR DESCRIPTION
Closes #1058.
Ref #1027.

We're restoring this as an alias of `Deno: Enable` because of documentation in the wild that might refer to this one.