### PR TITLE
feat: Show a modal dialog after workspace init

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -417,6 +417,7 @@ export function enable(
   return async () => {
     const config = vscode.workspace.getConfiguration(EXTENSION_NS);
     await config.update("enable", true);
+    vscode.window.showInformationMessage("Deno workspace initialized.");
   };
 }
 


### PR DESCRIPTION
Previously, the user was prompted with a few questions about their workspace configuration, making it clear that something was happening. Now that there is no more user input required, it is not clear that the extension is doing anything.

This change-set shows a show a modal info box to the user after the Deno workspace is initialized.

In a future commit, this should be replaced with a message to the status bar.