### PR TITLE
docs: correct the deno.unstable description

### DIFF
--- a/package.json
+++ b/package.json
@@ -477,7 +477,7 @@
         "deno.unstable": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Controls if code will be type checked with Deno's unstable APIs. This is the equivalent to using `--unstable` on the command line.\n\n**Not recommended to be enabled globally.**",
+          "markdownDescription": "Controls if tests will be run with the the `--unstable` flag when running tests via the explorer.\n\n**Not recommended to be enabled globally.**",
           "scope": "resource",
           "examples": [
             true,


### PR DESCRIPTION
the `deno.unstable` flag is only used to control test execution. This change-set updates the description to reflect that.