### PR TITLE
fix: handle nested config files in tasks sidebar

### DIFF
--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -30,6 +30,9 @@ export const registryState = new NotificationType<RegistryStateParams>(
 
 export interface TaskRequestResponse {
   name: string;
+  // TODO(nayeemrmn): `detail` is being renamed to `command`. Eventually update
+  // the server's serialization of this field to `command` and remove `detail`.
+  command: string | null;
   detail: string;
   sourceUri: string;
 }

--- a/client/src/tasks_sidebar.ts
+++ b/client/src/tasks_sidebar.ts
@@ -141,6 +141,7 @@ class DenoTaskProvider implements TaskProvider {
         workspaceFolders.reverse();
         const workspaceFolder = workspaceFolders.find((f) =>
           // NOTE: skipEncoding in Uri.toString(), read more at https://github.com/microsoft/vscode/commit/65cb3397673b922c1b6759d145a3a183feb3ee5d
+          // See https://github.com/denoland/vscode_deno/issues/991#issuecomment-1825340906.
           configTask.sourceUri
             .toLocaleLowerCase()
             .startsWith(f.uri.toString(true).toLocaleLowerCase())


### PR DESCRIPTION
Use the correct workspace folder and `-c subdir/deno.json` when executing subdirectory `deno.json` tasks via the sidebar. Also dedup some code.