### PR TITLE
feat: use --inspect-wait for prerelease deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: npx $VSCE_COMMAND package -o vscode-deno.vsix
 
       - name: Artifact upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: vscode-deno
           path: vscode-deno.vsix

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -30,7 +30,6 @@ import { createRegistryStateHandler } from "./notification_handlers";
 import { DenoServerInfo } from "./server_info";
 
 import * as dotenv from "dotenv";
-import * as semver from "semver";
 import * as vscode from "vscode";
 import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
 import type { Location, Position } from "vscode-languageclient/node";
@@ -39,6 +38,7 @@ import { denoUpgradePromptAndExecute } from "./upgrade";
 import { join } from "path";
 import { readFileSync } from "fs";
 import * as process from "process";
+import { semver } from "./semver";
 
 // deno-lint-ignore no-explicit-any
 export type Callback = (...args: any[]) => unknown;
@@ -261,9 +261,7 @@ export function startLanguageServer(
 
     if (
       semver.valid(extensionContext.serverInfo.version) &&
-      !semver.satisfies(extensionContext.serverInfo.version, SERVER_SEMVER, {
-        includePrerelease: true,
-      })
+      !semver.satisfies(extensionContext.serverInfo.version, SERVER_SEMVER)
     ) {
       notifyServerSemver(extensionContext.serverInfo.version);
     } else {

--- a/client/src/semver.ts
+++ b/client/src/semver.ts
@@ -1,0 +1,18 @@
+import * as semverPackage from "semver";
+import { Options, Range, SemVer } from "semver";
+
+export const semver = {
+  ...semverPackage,
+
+  satisfies: (
+    version: string | SemVer,
+    range: string | Range,
+    optionsOrLoose?: boolean | Options,
+  ): boolean => {
+    return semverPackage.satisfies(
+      version,
+      range,
+      optionsOrLoose ?? { includePrerelease: true },
+    );
+  },
+};

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -6,7 +6,6 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as process from "process";
-import * as semver from "semver";
 import {
   Location,
   Position,
@@ -16,6 +15,7 @@ import {
   WorkspaceFolder,
 } from "vscode";
 import { JSONVisitor, visit } from "jsonc-parser/lib/esm/main.js";
+import { semver } from "./semver";
 
 /** Assert that the condition is "truthy", otherwise throw. */
 export function assert(cond: unknown, msg = "Assertion failed."): asserts cond {


### PR DESCRIPTION
### Background

- I tried using deno 1.46.0-rc.0 and https://github.com/denoland/vscode_deno/pull/893 did not worked.
- https://github.com/denoland/vscode_deno/pull/1142 fixes one semver check of two usages.

### Changes

- Create new semver module for applying `{ includePrerelease: true }` for all `semver.satisfies` usages.

### How to test

With prerelease deno and windows, click 'Run Test | **Debug**' above Deno.test and see it does not pause at debug session start.
