### PR TITLE
feat: unstable setting as list

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,13 @@ extension has the following configuration options:
 To see which versions of this extension can be used with each version of the
 Deno CLI, consult the following table.
 
-| Deno CLI       | vscode-deno     |
-| -------------- | --------------- |
-| 1.37.2 onwards | 3.34.0 onwards  |
-| 1.37.1         | 3.32.0 - 3.33.3 |
-| 1.37.0         | 3.28.0 - 3.31.0 |
-| ? - 1.36.4     | 3.27.0          |
+| Deno CLI        | vscode-deno     |
+| --------------- | --------------- |
+| 1.40.0 onwards  | TODO onwards    |
+| 1.37.2 - 1.39.4 | 3.34.0 - 3.39.0 |
+| 1.37.1          | 3.32.0 - 3.33.3 |
+| 1.37.0          | 3.28.0 - 3.31.0 |
+| ? - 1.36.4      | 3.27.0          |
 
 Version ranges are inclusive. Incompatibilites prior to 3.27.0 were not tracked.
 

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -376,9 +376,9 @@ export function test(
     ];
     const unstable = config.get("unstable") as string[] ?? [];
     for (const unstableFeature of unstable) {
-      const flag = `--${unstableFeature}`;
+      const flag = `--unstable-${unstableFeature}`;
       if (!testArgs.includes(flag)) {
-        testArgs.push(unstableFeature);
+        testArgs.push(flag);
       }
     }
     if (options?.inspect) {

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -34,7 +34,7 @@ import * as semver from "semver";
 import * as vscode from "vscode";
 import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
 import type { Location, Position } from "vscode-languageclient/node";
-import { getWorkspacesEnabledInfo, setupCheckConfig } from "./enable";
+import { getWorkspacesEnabledInfo } from "./enable";
 import { denoUpgradePromptAndExecute } from "./upgrade";
 import { join } from "path";
 import { readFileSync } from "fs";
@@ -171,6 +171,20 @@ export function startLanguageServer(
       serverOptions,
       {
         outputChannel: extensionContext.outputChannel,
+        middleware: {
+          workspace: {
+            configuration: (params, token, next) => {
+              const response = next(params, token) as Record<string, unknown>[];
+              for (let i = 0; i < response.length; i++) {
+                const item = params.items[i];
+                if (item.section == "deno") {
+                  transformDenoConfiguration(extensionContext, response[i]);
+                }
+              }
+              return response;
+            },
+          },
+        },
         ...extensionContext.clientOptions,
       },
     );
@@ -214,51 +228,34 @@ export function startLanguageServer(
       ),
     );
 
-    // TODO(nayeemrmn): LSP version < 1.40.0 don't support the required API for
-    // "deno/didChangeDenoConfiguration". Remove this eventually.
-    if (semver.lt(extensionContext.serverInfo.version, "1.40.0")) {
-      extensionContext.scopesWithDenoJson = new Set();
-      extensionContext.clientSubscriptions.push(
-        extensionContext.client.onNotification(
-          "deno/didChangeDenoConfiguration",
-          () => {
-            extensionContext.tasksSidebar.refresh();
-          },
-        ),
-      );
-      extensionContext.clientSubscriptions.push(
-        await setupCheckConfig(extensionContext),
-      );
-    } else {
-      const scopesWithDenoJson = new Set<string>();
-      extensionContext.scopesWithDenoJson = scopesWithDenoJson;
-      extensionContext.clientSubscriptions.push(
-        extensionContext.client.onNotification(
-          "deno/didChangeDenoConfiguration",
-          ({ changes }: DidChangeDenoConfigurationParams) => {
-            let changedScopes = false;
-            for (const change of changes) {
-              if (change.configurationType != "denoJson") {
-                continue;
-              }
-              if (change.type == "added") {
-                const scopePath = vscode.Uri.parse(change.scopeUri).fsPath;
-                scopesWithDenoJson.add(scopePath);
-                changedScopes = true;
-              } else if (change.type == "removed") {
-                const scopePath = vscode.Uri.parse(change.scopeUri).fsPath;
-                scopesWithDenoJson.delete(scopePath);
-                changedScopes = true;
-              }
+    const scopesWithDenoJson = new Set<string>();
+    extensionContext.scopesWithDenoJson = scopesWithDenoJson;
+    extensionContext.clientSubscriptions.push(
+      extensionContext.client.onNotification(
+        "deno/didChangeDenoConfiguration",
+        ({ changes }: DidChangeDenoConfigurationParams) => {
+          let changedScopes = false;
+          for (const change of changes) {
+            if (change.configurationType != "denoJson") {
+              continue;
             }
-            if (changedScopes) {
-              extensionContext.tsApi?.refresh();
+            if (change.type == "added") {
+              const scopePath = vscode.Uri.parse(change.scopeUri).fsPath;
+              scopesWithDenoJson.add(scopePath);
+              changedScopes = true;
+            } else if (change.type == "removed") {
+              const scopePath = vscode.Uri.parse(change.scopeUri).fsPath;
+              scopesWithDenoJson.delete(scopePath);
+              changedScopes = true;
             }
-            extensionContext.tasksSidebar.refresh();
-          },
-        ),
-      );
-    }
+          }
+          if (changedScopes) {
+            extensionContext.tsApi?.refresh();
+          }
+          extensionContext.tasksSidebar.refresh();
+        },
+      ),
+    );
 
     extensionContext.tsApi.refresh();
 
@@ -306,6 +303,20 @@ function notifyServerSemver(serverVersion: string) {
     `The version of Deno language server ("${serverVersion}") does not meet the requirements of the extension ("${SERVER_SEMVER}"). Please update Deno and restart.`,
     "OK",
   );
+}
+
+/** Mutates the `config` parameter. For compatibility currently. */
+export function transformDenoConfiguration(
+  extensionContext: DenoExtensionContext,
+  config: Record<string, unknown>,
+) {
+  // TODO(nayeemrmn): Deno > 2.0.0-rc.1 expects `deno.unstable` as
+  // an array of features. Remove this eventually.
+  if (
+    semver.lte(extensionContext.serverInfo?.version || "1.0.0", "2.0.0-rc.1")
+  ) {
+    config.unstable = !!config.unstable;
+  }
 }
 
 function showWelcomePageIfFirstUse(
@@ -363,8 +374,12 @@ export function test(
     const testArgs: string[] = [
       ...(config.get<string[]>("codeLens.testArgs") ?? []),
     ];
-    if (config.get("unstable")) {
-      testArgs.push("--unstable");
+    const unstable = config.get("unstable") as string[] ?? [];
+    for (const unstableFeature of unstable) {
+      const flag = `--${unstableFeature}`;
+      if (!testArgs.includes(flag)) {
+        testArgs.push(unstableFeature);
+      }
     }
     if (options?.inspect) {
       testArgs.push(getInspectArg(extensionContext.serverInfo?.version));

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -138,8 +138,12 @@ export async function activate(
     },
     diagnosticCollectionName: "deno",
     initializationOptions: () => {
+      const denoConfiguration = vscode.workspace.getConfiguration().get(
+        EXTENSION_NS,
+      ) as Record<string, unknown>;
+      commands.transformDenoConfiguration(extensionContext, denoConfiguration);
       return {
-        ...vscode.workspace.getConfiguration().get(EXTENSION_NS),
+        ...denoConfiguration,
         javascript: vscode.workspace.getConfiguration().get("javascript"),
         typescript: vscode.workspace.getConfiguration().get("typescript"),
         enableBuiltinCommands: true,

--- a/client/src/upgrade.ts
+++ b/client/src/upgrade.ts
@@ -28,7 +28,7 @@ export async function denoUpgradePromptAndExecute(
   const args = ["upgrade"];
   const unstable = config.get("unstable") as string[] ?? [];
   for (const unstableFeature of unstable) {
-    args.push(`--${unstableFeature}`);
+    args.push(`--unstable-${unstableFeature}`);
   }
   if (isCanary) {
     args.push("--canary");

--- a/client/src/upgrade.ts
+++ b/client/src/upgrade.ts
@@ -26,8 +26,9 @@ export async function denoUpgradePromptAndExecute(
     return;
   }
   const args = ["upgrade"];
-  if (config.get("unstable")) {
-    args.push("--unstable");
+  const unstable = config.get("unstable") as string[] ?? [];
+  for (const unstableFeature of unstable) {
+    args.push(`--${unstableFeature}`);
   }
   if (isCanary) {
     args.push("--canary");

--- a/package.json
+++ b/package.json
@@ -508,14 +508,13 @@
           "scope": "window"
         },
         "deno.unstable": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Controls if tests will be run with the the `--unstable` flag when running tests via the explorer.\n\n**Not recommended to be enabled globally.**",
-          "scope": "resource",
-          "examples": [
-            true,
-            false
-          ]
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Controls which `--unstable-*` features tests will be run with when running them via the explorer.\n\n**Not recommended to be enabled globally.**",
+          "scope": "resource"
         },
         "deno.lint": {
           "type": "boolean",


### PR DESCRIPTION
Coupled with https://github.com/denoland/deno/pull/25552. This change would be breaking but it adds a configuration hook which reverts the setting to a boolean for older versions of the CLI/server.

Also removes some old compat paths. Unsupports Deno <= 1.39.4.