### PR TITLE
Run tests with file watcher

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,11 +16,11 @@
       },
       "devDependencies": {
         "@types/semver": "7.3.9",
-        "@types/vscode": "1.67.0",
+        "@types/vscode": "1.77.0",
         "vscode-test": "^1.6.1"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.77.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -39,10 +39,11 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
-      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
-      "dev": true
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+      "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -541,9 +542,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
-      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+      "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
       "dev": true
     },
     "agent-base": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/denoland/vscode_deno"
   },
   "engines": {
-    "vscode": "^1.60.0"
+    "vscode": "^1.77.0"
   },
   "dependencies": {
     "dotenv": "^16.4.5",
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/semver": "7.3.9",
-    "@types/vscode": "1.67.0",
+    "@types/vscode": "1.77.0",
     "vscode-test": "^1.6.1"
   }
 }

--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -98,6 +98,9 @@ export interface TestRunRequestParams {
   /** The run kind. Currently Deno only supports `"run"` */
   kind: "run" | "coverage" | "debug";
 
+  /** Whether the run should watch the files and continously re-run. */
+  isContinuous: boolean;
+
   /** Test modules or tests to exclude from the test run. */
   exclude?: TestIdentifier[];
 

--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -213,6 +213,11 @@ interface TestOutput {
   location?: Location;
 }
 
+interface TestRunRestart {
+  type: "restart";
+  enqueued: EnqueuedTestModule[]
+}
+
 interface TestEnd {
   /** The test run has ended. */
   type: "end";
@@ -223,6 +228,7 @@ type TestRunProgressMessage =
   | TestFailedErrored
   | TestPassed
   | TestOutput
+  | TestRunRestart
   | TestEnd;
 
 export interface TestRunProgressParams {

--- a/client/src/testing.ts
+++ b/client/src/testing.ts
@@ -159,6 +159,7 @@ export class DenoTestController implements vscode.Disposable {
           kind = "debug";
           break;
       }
+      const isContinuous = request.continuous ?? false;
       const include = request.include
         ? request.include.map(asTestIdentifier)
         : undefined;
@@ -168,6 +169,7 @@ export class DenoTestController implements vscode.Disposable {
       const { enqueued } = await client.sendRequest(testRun, {
         id,
         kind,
+        isContinuous,
         include,
         exclude,
       });
@@ -194,6 +196,8 @@ export class DenoTestController implements vscode.Disposable {
       vscode.TestRunProfileKind.Run,
       runHandler,
       true,
+      undefined,
+      true
     );
     // TODO(@kitsonk) add debug run profile
     // TODO(@kitsonk) add coverage run profile
@@ -213,7 +217,7 @@ export class DenoTestController implements vscode.Disposable {
           expectedOutput,
           actualOutput,
         )
-        : new vscode.TestMessage(msg);
+          : new vscode.TestMessage(msg);
 
       if (location) {
         testMessage.location = p2c.asLocation(location);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typescript": "^5.0.2"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.77.0"
       }
     },
     "node_modules/@types/node": {
@@ -405,7 +405,7 @@
         "typescript": "^5.0.2"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.77.0"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "deno"
   ],
   "engines": {
-    "vscode": "^1.60.0"
+    "vscode": "^1.77.0"
   },
   "activationEvents": [
     "onLanguage:typescript",
@@ -257,7 +257,9 @@
           "markdownDescription": "Additional environment variables to pass to Deno processes. Overrides the user's env and `deno.envFile`. These will be overridden by more specific settings such as `deno.future` for `DENO_FUTURE`, and invariables like `NO_COLOR=1`.",
           "scope": "window",
           "examples": [
-            { "HTTP_PROXY": "http://localhost:8080" }
+            {
+              "HTTP_PROXY": "http://localhost:8080"
+            }
           ]
         },
         "deno.envFile": {
@@ -479,7 +481,11 @@
           "scope": "resource"
         },
         "deno.trace.server": {
-          "enum": ["messages", "off", "verbose"],
+          "enum": [
+            "messages",
+            "off",
+            "verbose"
+          ],
           "default": "off",
           "markdownDescription": "Traces the communication between VS Code and the Deno Language Server.",
           "scope": "window"

--- a/typescript-deno-plugin/package-lock.json
+++ b/typescript-deno-plugin/package-lock.json
@@ -12,7 +12,7 @@
         "typescript": "^5.0.2"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.77.0"
       }
     },
     "node_modules/typescript": {

--- a/typescript-deno-plugin/package.json
+++ b/typescript-deno-plugin/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/denoland/vscode_deno"
   },
   "engines": {
-    "vscode": "^1.60.0"
+    "vscode": "^1.77.0"
   },
   "devDependencies": {
     "typescript": "^5.0.2"


### PR DESCRIPTION
I wanted a Deno testing experience that's closer to Vitest's UI or Wallaby.js. As in
- See the test results inline in the IDE
- Re-run the tests and update the IDE's UI when saving 

This now works 🎉 
https://github.com/user-attachments/assets/b283b1e1-528f-47d5-b436-86c546d0d3c7

(The execution speed is very slow, because I have not compiled Deno in release mode)

To do so, I had to
- Bump the required VSCode version. This lets us take advantage of VSCode's "continuous run".
- Update the LSP to support these features. https://github.com/denoland/deno/pull/27762
- Recreate the TestRun object when the tests are being restarted. This is because VSCode does not support changing the status of a test from failure back to success.
- Learn about a VSCode peculiarity https://github.com/microsoft/vscode/issues/172205


Fix #1132 

