### PR TITLE
fix(client): set `{ shell: true }` in server options for "deno.{bat,cmd}"

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -32,7 +32,11 @@ import { DenoServerInfo } from "./server_info";
 import * as dotenv from "dotenv";
 import * as vscode from "vscode";
 import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
-import type { Location, Position } from "vscode-languageclient/node";
+import type {
+  Executable,
+  Location,
+  Position,
+} from "vscode-languageclient/node";
 import { getWorkspacesEnabledInfo, isPathEnabled } from "./enable";
 import { denoUpgradePromptAndExecute } from "./upgrade";
 import * as fs from "fs";
@@ -164,19 +168,21 @@ export function startLanguageServer(
     env["NO_COLOR"] = "1";
     env["DENO_V8_FLAGS"] = getV8Flags();
 
+    const shell = process.platform === "win32" &&
+      /\.([Cc][Mm][Dd]|[Bb][Aa][Tt])$/.test(command);
     const serverOptions: ServerOptions = {
       run: {
         command,
         args: ["lsp"],
-        options: { env },
-      },
+        options: { env, shell },
+      } as Executable,
       debug: {
         command,
         // disabled for now, as this gets super chatty during development
         // args: ["lsp", "-L", "debug"],
         args: ["lsp"],
-        options: { env },
-      },
+        options: { env, shell },
+      } as Executable,
     };
     const client = new LanguageClient(
       LANGUAGE_CLIENT_ID,


### PR DESCRIPTION
Fixes "Deno Language Server client: couldn't create connection to server. Error: spawn EINVAL" #1257

I've debugged it locally to ensure it works on my Windows PC.

---

`vscode_deno` is currently broken on Win32 VSCode 1.92 (July 2024) and later. `spawn`'s/`spawnSync`'s EINVAL error was introduced in the Node.js 18.x, 20.x, 21.x releases lines to mitigate CVE-2024-27980. The fix was implemented at nodejs/node@69ffc6d50d.

Running a .bat or .cmd via spawn or spawnSync _without assigning the shell option_ is prohibited in VSCode 1.92 and later.