### PR TITLE
fix: enable paths in the global npm cache

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,6 +17,7 @@ import * as util from "util";
 
 import * as vscode from "vscode";
 import { registerSidebar } from "./tasks_sidebar";
+import { getDenoInfoJson } from "./util";
 
 function handleConfigurationChange(event: vscode.ConfigurationChangeEvent) {
   if (
@@ -79,6 +80,9 @@ export async function activate(
 ): Promise<void> {
   extensionContext.outputChannel = extensionContext.outputChannel ??
     vscode.window.createOutputChannel(LANGUAGE_CLIENT_NAME);
+  extensionContext.denoInfoJson = await getDenoInfoJson(
+    extensionContext.outputChannel,
+  );
   const p2cMap = new Map<string, string>();
   extensionContext.clientOptions = {
     documentSelector: [
@@ -228,6 +232,7 @@ export async function activate(
       enableSettingsUnscoped: extensionContext.enableSettingsUnscoped,
       enableSettingsByFolder: extensionContext.enableSettingsByFolder,
       scopesWithDenoJson: Array.from(extensionContext.scopesWithDenoJson ?? []),
+      npmCache: extensionContext.denoInfoJson?.npmCache ?? null,
     };
   });
 

--- a/client/src/shared_types.d.ts
+++ b/client/src/shared_types.d.ts
@@ -12,4 +12,5 @@ export interface PluginSettings {
   enableSettingsUnscoped: EnableSettings;
   enableSettingsByFolder: [string, EnableSettings][];
   scopesWithDenoJson: string[];
+  npmCache: string | null;
 }

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -35,6 +35,7 @@ export interface DenoExtensionContext {
     | ServerCapabilities<DenoExperimental>
     | undefined;
   scopesWithDenoJson: Set<string> | undefined;
+  denoInfoJson: DenoInfoJson | null;
   statusBar: DenoStatusBar;
   tsApi: TsApi;
   outputChannel: vscode.OutputChannel;
@@ -46,6 +47,10 @@ export interface DenoExtensionContext {
 
 export interface TestCommandOptions {
   inspect: boolean;
+}
+
+export interface DenoInfoJson {
+  npmCache?: string;
 }
 
 export interface UpgradeAvailable {

--- a/typescript-deno-plugin/src/index.ts
+++ b/typescript-deno-plugin/src/index.ts
@@ -60,6 +60,11 @@ class Plugin implements ts.server.PluginModule {
     if (!pluginSettings) {
       return false;
     }
+    if (pluginSettings.npmCache) {
+      if (pathStartsWith(fileName, pluginSettings.npmCache)) {
+        return true;
+      }
+    }
     const enableSettings =
       pluginSettings.enableSettingsByFolder?.find(([workspace, _]) =>
         pathStartsWith(fileName, workspace)


### PR DESCRIPTION
Go-to definition points to these and they are enabled server-side. Also enable them here so they don't get diagnostics from the built-in TS server.

Related: https://github.com/denoland/deno/issues/27291#issuecomment-2557025337