### PR TITLE
Enable colored output in tests

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -159,6 +159,7 @@ export function startLanguageServer(
       }
     }
     const denoEnv = config.get<Record<string, string>>("env");
+    env["FORCE_COLOR"] = "1";
     if (denoEnv) {
       Object.assign(env, denoEnv);
     }


### PR DESCRIPTION
I disabled the `env["NO_COLOR"]` setting for the Deno that is spawned. 

Instead, since VSCode actually handles ANSI color escapes, I *forcibly enable* the color setting. The reasoning is that it's entirely possible to start VSCode from the terminal. (e.g. when I configure my git editor to be VSCode, then VSCode gets started from the terminal).
And I do think that it would be confusing if the NO_COLOR terminal setting would affect the test output inside a GUI application. 

![absolutely gorgeous colors in VSCode](https://github.com/user-attachments/assets/ab7c5ac5-5ac5-4906-a97a-c2bd79ae7776)


Since I don't know the full impact of this change: *What should I test?*
Could this change, for example, break the Deno LSP tests?

### Investigation

As far as I can tell from the git blame, the `env["NO_COLOR"]` was added [4 years ago](https://github.com/denoland/vscode_deno/pull/454/commits/8e2119433932f13b02414e2e1ae13b90c73b653a), but I couldn't dig up further information as to why. 

### Linked issues

Fixes https://github.com/denoland/vscode_deno/issues/1156
Fixes https://github.com/denoland/vscode_deno/issues/1267