### PR TITLE
feat: add deno.semanticHighlighting.enabled setting to disable LSP-provided semantic tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ extension has the following configuration options:
   the extension will disable the built-in VSCode JavaScript and TypeScript
   language services, and will use the Deno Language Server (`deno lsp`) instead.
   _boolean, default `false`_
+- `deno.semanticHighlighting.enabled`: Controls if the extension provides semantic
+  tokens to VS Code. Disable this to use VS Code's built-in JavaScript and
+  TypeScript syntax highlighting instead. _boolean, default `true`_
 - `deno.disablePaths`: Controls if the Deno Language Server is disabled for
   specific paths of the workspace folder. Defaults to an empty list.
 - `deno.enablePaths`: Controls if the Deno Language Server is enabled for only

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -31,7 +31,7 @@ import { DenoServerInfo } from "./server_info";
 
 import * as dotenv from "dotenv";
 import * as vscode from "vscode";
-import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
+import { ServerOptions } from "vscode-languageclient/node";
 import type {
   Executable,
   Location,
@@ -43,6 +43,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as process from "process";
 import { semver } from "./semver";
+import { DenoLanguageClient } from "./deno_language_client";
 
 // deno-lint-ignore no-explicit-any
 export type Callback = (...args: any[]) => unknown;
@@ -184,7 +185,7 @@ export function startLanguageServer(
         options: { env, shell },
       } as Executable,
     };
-    const client = new LanguageClient(
+    const client = new DenoLanguageClient(
       LANGUAGE_CLIENT_ID,
       LANGUAGE_CLIENT_NAME,
       serverOptions,

--- a/client/src/deno_language_client.ts
+++ b/client/src/deno_language_client.ts
@@ -1,0 +1,25 @@
+import {
+  LanguageClient,
+  type StaticFeature,
+  type DynamicFeature,
+  SemanticTokensRegistrationType,
+} from "vscode-languageclient/node";
+
+export class DenoLanguageClient extends LanguageClient {
+  override registerFeature(
+    feature: StaticFeature | DynamicFeature<unknown>,
+  ): void {
+    const registrationType = (feature as {
+      registrationType?: { method: string };
+    }).registrationType;
+    const clientOptions = this.clientOptions.initializationOptions();
+    const semanticHighlightingIsEnabled = clientOptions.semanticHighlighting?.enabled ?? true;
+    const skipSemanticTokensRegistration = !semanticHighlightingIsEnabled && registrationType?.method === SemanticTokensRegistrationType.method;
+
+    if (skipSemanticTokensRegistration) {
+      return;
+    }
+
+    super.registerFeature(feature);
+  }
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -48,6 +48,7 @@ function handleConfigurationChange(event: vscode.ConfigurationChangeEvent) {
       event.affectsConfiguration("deno.env") ||
       event.affectsConfiguration("deno.envFile") ||
       event.affectsConfiguration("deno.future") ||
+      event.affectsConfiguration("deno.semanticHighlighting.enabled") ||
       event.affectsConfiguration("deno.internalInspect") ||
       event.affectsConfiguration("deno.logFile") ||
       event.affectsConfiguration("deno.path") ||

--- a/package.json
+++ b/package.json
@@ -198,6 +198,16 @@
             false
           ]
         },
+        "deno.semanticHighlighting.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Controls if the extension provides semantic tokens for files it manages. Set to false to rely on the built-in VS Code JavaScript and TypeScript syntax highlighting instead. Requires restarting the Deno language server to take effect.",
+          "scope": "resource",
+          "examples": [
+            true,
+            false
+          ]
+        },
         "deno.cacheOnSave": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
This adds a setting (`deno.semanticHighlighting.enabled`) to disable the semantic tokens from the LSP that provide syntax highlighting.  The name of the setting was inspired by the built-in `editor.semanticHighlighting.enabled`.

I added this because the Deno extension completely overrides any extensions that provide their own semantic tokens for parts of a document.  Setting this proposed setting to `false` causes VS Code to use the default Typescript/JavaScript highlighting and allows other extensions to provide semantic tokens while still leaving the other features of this extension enabled.