### PR TITLE
feat: add toggles for organize imports and symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,13 +206,13 @@ extension has the following configuration options:
   by the Deno Language Server to host its TS server.
 - `deno.lint`: Controls if linting information will be provided by the Deno
   Language Server. _boolean, default `true`_
-- `deno.provide.organizeImports`: Controls if the Deno language server
+- `deno.organizeImports.enabled`: Controls if the Deno language server
   contributes organize imports code actions. Disable to rely on VS Code's
   built-in TypeScript/JavaScript organizer. _boolean, default `true`_
-- `deno.provide.symbols.document`: Controls if the Deno language server
+- `deno.symbols.document.enabled`: Controls if the Deno language server
   contributes document symbols. Disable to rely on VS Code's built-in provider.
   _boolean, default `true`_
-- `deno.provide.symbols.workspace`: Controls if the Deno language server
+- `deno.symbols.workspace.enabled`: Controls if the Deno language server
   contributes workspace symbols. Disable to rely on VS Code's built-in
   provider. _boolean, default `true`_
 - `deno.maxTsServerMemory`: Maximum amount of memory the TypeScript isolate can

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -221,7 +221,7 @@ export function startLanguageServer(
             const actions = await next(document, range, context, token);
             if (
               actions == null || !Array.isArray(actions) ||
-              isProvideSettingEnabled("provide.organizeImports", document.uri)
+              isProvideSettingEnabled("organizeImports.enabled", document.uri)
             ) {
               return actions;
             }
@@ -231,13 +231,13 @@ export function startLanguageServer(
             });
           },
           provideDocumentSymbols: (document, token, next) => {
-            if (!isProvideSettingEnabled("provide.symbols.document", document.uri)) {
+            if (!isProvideSettingEnabled("symbols.document.enabled", document.uri)) {
               return [];
             }
             return next(document, token);
           },
           provideWorkspaceSymbols: (query, token, next) => {
-            if (!isProvideSettingEnabled("provide.symbols.workspace")) {
+            if (!isProvideSettingEnabled("symbols.workspace.enabled")) {
               return [];
             }
             return next(query, token);

--- a/package.json
+++ b/package.json
@@ -547,7 +547,7 @@
             false
           ]
         },
-        "deno.provide.organizeImports": {
+        "deno.organizeImports.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Controls if the Deno language server contributes organize imports code actions. Disable to rely on VS Code's built-in TypeScript/JavaScript organize imports instead.",
@@ -557,7 +557,7 @@
             false
           ]
         },
-        "deno.provide.symbols.document": {
+        "deno.symbols.document.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Controls if the Deno language server provides document symbols. Disable to rely on VS Code's built-in providers instead.",
@@ -567,7 +567,7 @@
             false
           ]
         },
-        "deno.provide.symbols.workspace": {
+        "deno.symbols.workspace.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Controls if the Deno language server provides workspace symbols. Disable to rely on VS Code's built-in providers instead.",


### PR DESCRIPTION
fix #1202 (and #1345 ?)

- Add new settings to let users disable Deno-provided organize-imports and document/workspace symbols.
- Filter these providers in language client middleware when disabled to avoid duplicate VS Code features.
- Document the new settings in README.