### PR TITLE
feat: add test coverage visualization

### DIFF
--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -216,7 +216,7 @@ interface TestOutput {
 
 interface TestRunRestart {
   type: "restart";
-  enqueued: EnqueuedTestModule[]
+  enqueued: EnqueuedTestModule[];
 }
 
 interface TestEnd {
@@ -264,3 +264,29 @@ export const virtualTextDocument = new RequestType<
   string,
   void
 >("deno/virtualTextDocument");
+
+export interface FileCoverage {
+  /** The URI of the file */
+  uri: string;
+
+  /** Lines that were executed (1-indexed line numbers) */
+  coveredLines: number[];
+
+  /** Lines that were not executed (1-indexed line numbers) */
+  uncoveredLines: number[];
+
+  /** Coverage percentage for this file */
+  coveragePercent: number;
+}
+
+export interface CoverageNotificationParams {
+  /** The test run ID this coverage belongs to */
+  id: number;
+
+  /** Coverage data for each file */
+  files: FileCoverage[];
+}
+
+export const testCoverage = new NotificationType<CoverageNotificationParams>(
+  "deno/testCoverage",
+);


### PR DESCRIPTION
Adds client-side support for the `deno/testCoverage` LSP notification, enabling visual coverage feedback directly in the editor.

This creates a "Run with Coverage" profile in the Test Explorer. When tests finish, the extension receives coverage data from the LSP and:
- Highlights covered lines with a green background (using `diffEditor.insertedTextBackground`)
- Highlights uncovered lines with a red background (using `diffEditor.removedTextBackground`)
- Shows an overview in the ruler lane for quick navigation
- Displays a summary message with the average coverage percentage

The decorations update automatically when switching between editor tabs, so you can navigate through your codebase and see coverage for each file.

**Technical details:**
- New types in `lsp_extensions.ts`: `FileCoverage`, `CoverageNotificationParams`, and the `testCoverage` notification
- Coverage handling integrated into `DenoTestController` in `testing.ts`, reusing the existing test run infrastructure

**Dependencies:**
Requires the corresponding LSP changes in denoland/deno#31739

Screenshots will be added in a follow-up comment.
<img width="1000" height="659" alt="scr01" src="https://github.com/user-attachments/assets/cf25dcd1-b00d-42a3-8316-c145482e1f43" />
<img width="1000" height="659" alt="scr02" src="https://github.com/user-attachments/assets/36c239fb-a272-4bc7-9dfa-75463048e632" />

