### PR TITLE
fix: register $ref'd config sub-schemas so VS Code trusts them

### DIFF
--- a/package.json
+++ b/package.json
@@ -559,6 +559,14 @@
         "url": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json"
       },
       {
+        "fileMatch": [],
+        "url": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/lint-rules.v1.json"
+      },
+      {
+        "fileMatch": [],
+        "url": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/lint-tags.v1.json"
+      },
+      {
         "fileMatch": "deno-import-intellisense.json",
         "url": "./schemas/registry-completions.schema.json"
       },


### PR DESCRIPTION
Opening `deno.json` in VS Code shows a persistent warning that the lint
schema is loaded from an untrusted location:

> Unable to load schema from
> 'https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/lint-rules.v1.json':
> Location ... is untrusted.

The `deno.json` schema is registered here from a remote
`raw.githubusercontent.com` URL, and its lint section resolves through
relative `$ref`s to sibling `lint-rules.v1.json` and `lint-tags.v1.json`
files. VS Code's JSON language service (`isTrusted()` in
`json-language-features`) only trusts schema URLs that are explicitly
registered: an exact-URL match against `jsonValidation` associations, the
`json.schemas` setting, or `json.schemaDownload.trustedDomains`. A schema
reached only transitively through a `$ref`, even on the same host, is
treated as an untrusted download and blocked. That's why the top-level
`config-file.v1.json` loads fine but its `$ref` targets do not, and the
`lint.rules` subsection silently loses schema validation.

This registers those two sibling schema URLs as `jsonValidation`
associations so `isTrusted()` matches them and the `$ref` download is
allowed. `fileMatch` is empty because these are sub-schemas (a single rule
name / tag value), not whole-file schemas, so they should never validate a
file on their own; the empty array still registers the association purely
for the trust check (`[].every(isString)` passes VS Code's contribution
validation).

Only `lint-rules.v1.json` and `lint-tags.v1.json` need this, as they are
the only cross-file `$ref` targets in `config-file.v1.json`.

Closes denoland/deno#35691
