### PR TITLE
feat(testing): add support for coverage streaming from LSP

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,15 +7,14 @@ Thank you, we appreciate your help!
 
 ## Prerequisites
 
-Most changes & feature enhancements don't require the extension to be
-modified, as the majority of the data used in the extension is supplied by
-the **Deno Language Server** which is integrated into the **[Deno CLI]**.
+Most changes & feature enhancements don't require the extension to be modified,
+as the majority of the data used in the extension is supplied by the **Deno
+Language Server** which is integrated into the **[Deno CLI]**.
 
 <br>
 
-If you already have this VSCode extension installed from the Marketplace,
-note that there is no need to uninstall it for development as it is
-automatically
+If you already have this VSCode extension installed from the Marketplace, note
+that there is no need to uninstall it for development as it is automatically
 replaced when the `Launch Client` instance is running.
 
 <br>
@@ -33,12 +32,10 @@ replaced when the `Launch Client` instance is running.
    npm install
    ```
 
-4. In the **VSCode Debug Menu**
-   start the `Launch Client` task
+4. In the **VSCode Debug Menu** start the `Launch Client` task
 
-5. In the **VSCode Debug Menu**
-   use the restart button after you
-   have made changes to reload
+5. In the **VSCode Debug Menu** use the restart button after you have made
+   changes to reload
 
 <br>
 <br>
@@ -46,8 +43,8 @@ replaced when the `Launch Client` instance is running.
 ## Pull Requests
 
 Once you are ready to open a ( draft ) pull request, give it a 𝗧𝗶𝘁𝗹𝗲 and
-𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻 that help people - that don't know of your changes - to
-understand what, how and why you did what you did.
+𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻 that help people - that don't know of your changes - to understand
+what, how and why you did what you did.
 
 _It's helpful to link related [𝗜𝘀𝘀𝘂𝗲𝘀] & [𝗗𝗶𝘀𝗰𝘂𝘀𝘀𝗶𝗼𝗻𝘀] !_
 

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ extension has the following configuration options:
   contributes document symbols. Disable to rely on VS Code's built-in provider.
   _boolean, default `true`_
 - `deno.symbols.workspace.enabled`: Controls if the Deno language server
-  contributes workspace symbols. Disable to rely on VS Code's built-in
-  provider. _boolean, default `true`_
+  contributes workspace symbols. Disable to rely on VS Code's built-in provider.
+  _boolean, default `true`_
 - `deno.maxTsServerMemory`: Maximum amount of memory the TypeScript isolate can
   use. Defaults to 3072 (3GB).
 - `deno.suggest.imports.hosts`: A map of domain hosts (origins) that are used

--- a/client/src/lsp_extensions.ts
+++ b/client/src/lsp_extensions.ts
@@ -224,12 +224,28 @@ interface TestEnd {
   type: "end";
 }
 
+export interface TestRunLineCoverage {
+  line: number;
+  count: number;
+}
+
+export interface TestRunCoverage {
+  textDocument: TextDocumentIdentifier;
+  lineCoverage: TestRunLineCoverage[];
+}
+
+interface TestCoverage {
+  type: "coverage";
+  value: TestRunCoverage[];
+}
+
 type TestRunProgressMessage =
   | TestEnqueuedStartedSkipped
   | TestFailedErrored
   | TestPassed
   | TestOutput
   | TestRunRestart
+  | TestCoverage
   | TestEnd;
 
 export interface TestRunProgressParams {

--- a/client/src/testing.ts
+++ b/client/src/testing.ts
@@ -219,8 +219,14 @@ export class DenoTestController implements vscode.Disposable {
       undefined,
       true,
     );
-    // TODO(@kitsonk) add debug run profile
-    // TODO(@kitsonk) add coverage run profile
+    testController.createRunProfile(
+      "Run with Coverage",
+      vscode.TestRunProfileKind.Coverage,
+      runHandler,
+      true,
+      undefined,
+      true,
+    );
 
     const p2c = client.protocol2CodeConverter;
 
@@ -363,6 +369,26 @@ export class DenoTestController implements vscode.Disposable {
             }
           }
           this.#runs.set(id, { run: newRun, request: runData.request });
+          break;
+        }
+        case "coverage": {
+          for (const fileCoverage of message.value) {
+            const uri = p2c.asUri(fileCoverage.textDocument.uri);
+            const statementCoverage: vscode.StatementCoverage[] = [];
+            for (const lineCoverage of fileCoverage.lineCoverage) {
+              statementCoverage.push(
+                new vscode.StatementCoverage(
+                  lineCoverage.count,
+                  new vscode.Position(lineCoverage.line, 0),
+                ),
+              );
+            }
+            const vscodeFileCoverage = vscode.FileCoverage.fromDetails(
+              uri,
+              statementCoverage,
+            );
+            run.addCoverage(vscodeFileCoverage);
+          }
           break;
         }
         case "end": {


### PR DESCRIPTION
Consumes the TestRunProgress coverage payloads from the language server and populates the VS Code Testing API with StatementCoverage.